### PR TITLE
String parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ python = "~2.7 || ^3.4"
 # enum34 is needed for Python 2.7
 enum34 = { version = "^1.1", python = "~2.7" }
 
+# functools32 is needed for Python 2.7
+functools32 = { version = "^3.2.3", python = "~2.7" }
+
 # The typing module is not in the stdlib in Python 2.7 and 3.4
 typing = { version = "^3.6", python = "~2.7 || ~3.4" }
 

--- a/tests/examples/invalid/newline_in_singleline_string.toml
+++ b/tests/examples/invalid/newline_in_singleline_string.toml
@@ -1,0 +1,3 @@
+this = "this
+that
+more"

--- a/tests/examples/invalid/string_slash_whitespace_char.toml
+++ b/tests/examples/invalid/string_slash_whitespace_char.toml
@@ -1,0 +1,1 @@
+invalid_escape = """this \    more"""

--- a/tests/examples/newline_in_strings.toml
+++ b/tests/examples/newline_in_strings.toml
@@ -1,0 +1,5 @@
+this = "this\\nthat\\nmore"
+foo = """bar
+baz
+qux
+"""

--- a/tests/examples/preserve_quotes_in_string.toml
+++ b/tests/examples/preserve_quotes_in_string.toml
@@ -1,0 +1,3 @@
+this = """this
+""
+more"""

--- a/tests/examples/string_slash_whitespace_newline.toml
+++ b/tests/examples/string_slash_whitespace_newline.toml
@@ -1,0 +1,5 @@
+no_whitespace = """hello \
+    world"""
+
+has_whitespace = """hello \
+    world"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from tomlkit import parse
 from tomlkit.exceptions import InvalidNumberOrDateError
 from tomlkit.exceptions import MixedArrayTypesError
 from tomlkit.exceptions import UnexpectedCharError
+from tomlkit.exceptions import InvalidCharInStringError
 from tomlkit.items import AoT
 from tomlkit.items import Array
 from tomlkit.items import Bool
@@ -45,6 +46,9 @@ def json_serial(obj):
         "pyproject",
         "0.5.0",
         "test",
+        "newline_in_strings",
+        "preserve_quotes_in_string",
+        "string_slash_whitespace_newline",
     ],
 )
 def test_parse_can_parse_valid_toml_files(example, example_name):
@@ -71,6 +75,8 @@ def test_parsed_document_are_properly_json_representable(
         ("mixed_array_types", MixedArrayTypesError),
         ("invalid_number", InvalidNumberOrDateError),
         ("trailing_comma", UnexpectedCharError),
+        ("newline_in_singleline_string", InvalidCharInStringError),
+        ("string_slash_whitespace_char", InvalidCharInStringError),
     ],
 )
 def test_parse_raises_errors_for_invalid_toml_files(

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -95,62 +95,32 @@ class StringType(Enum):
     @property
     @lru_cache(maxsize=None)
     def unit(self):  # type: () -> str
-        try:
-            # use cached value
-            return self._unit
-        except AttributeError:
-            self._unit = self.value[0]
-            return self._unit
+        return self.value[0]
 
     @lru_cache(maxsize=None)
     def is_basic(self):  # type: () -> bool
-        try:
-            # use cached value
-            return self._basic
-        except AttributeError:
-            self._basic = self in {StringType.SLB, StringType.MLB}
-            return self._basic
+        return self in {StringType.SLB, StringType.MLB}
 
     @lru_cache(maxsize=None)
     def is_literal(self):  # type: () -> bool
-        try:
-            # use cached value
-            return self._literal
-        except AttributeError:
-            self._literal = self in {StringType.SLL, StringType.MLL}
-            return self._literal
+        return self in {StringType.SLL, StringType.MLL}
 
     @lru_cache(maxsize=None)
     def is_singleline(self):  # type: () -> bool
-        try:
-            # use cached value
-            return self._singleline
-        except AttributeError:
-            self._singleline = self in {StringType.SLB, StringType.SLL}
-            return self._singleline
+        return self in {StringType.SLB, StringType.SLL}
 
     @lru_cache(maxsize=None)
     def is_multiline(self):  # type: () -> bool
-        try:
-            # use cached value
-            return self._multiline
-        except AttributeError:
-            self._multiline = self in {StringType.MLB, StringType.MLL}
-            return self._multiline
+        return self in {StringType.MLB, StringType.MLL}
 
     @lru_cache(maxsize=None)
     def toggle(self):  # type: () -> StringType
-        try:
-            # use cached value
-            return self._other
-        except AttributeError:
-            self._other = {
-                StringType.SLB: StringType.MLB,
-                StringType.MLB: StringType.SLB,
-                StringType.SLL: StringType.MLL,
-                StringType.MLL: StringType.SLL,
-            }[self]
-            return self._other
+        return {
+            StringType.SLB: StringType.MLB,
+            StringType.MLB: StringType.SLB,
+            StringType.SLL: StringType.MLL,
+            StringType.MLL: StringType.SLL,
+        }[self]
 
 
 class Trivia:

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -755,7 +755,6 @@ class Parser:
             # consume the newline, EOF here is an issue (middle of string)
             self.inc(exception=UnexpectedEofError)
 
-        ESCAPE = "\\"
         escaped = False  # whether the previous key was ESCAPE
         while True:
             if delim.is_singleline() and self._current.is_nl():
@@ -800,7 +799,7 @@ class Parser:
 
                 # no longer escaped
                 escaped = False
-            elif delim.is_basic() and self._current == ESCAPE:
+            elif delim.is_basic() and self._current == "\\":
                 # the next char is being escaped
                 escaped = True
 

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -79,7 +79,7 @@ class Parser:
         else:
             return self._src[self._marker : self._idx]
 
-    def inc(self):  # type: () -> bool
+    def inc(self, exception=None):  # type: () -> bool
         """
         Increments the parser if the end of the input has not been reached.
         Returns whether or not it was able to advance.
@@ -92,15 +92,17 @@ class Parser:
             self._idx = len(self._src)
             self._current = TOMLChar("\0")
 
-            return False
+            if not exception:
+                return False
+            raise exception
 
-    def inc_n(self, n):  # type: (int) -> bool
+    def inc_n(self, n, exception=None):  # type: (int) -> bool
         """
         Increments the parser by n characters
         if the end of the input has not been reached.
         """
         for _ in range(n):
-            if not self.inc():
+            if not self.inc(exception=exception):
                 return False
 
         return True
@@ -673,140 +675,145 @@ class Parser:
                 return
 
     def _parse_literal_string(self):  # type: () -> Item
-        return self._parse_string("'")
+        return self._parse_string(StringType.SLL)
 
     def _parse_basic_string(self):  # type: () -> Item
-        return self._parse_string('"')
+        return self._parse_string(StringType.SLB)
 
     def _parse_string(self, delim):  # type: (str) -> Item
-        multiline = False
+        delim = StringType(delim)
+        assert delim.is_singleline()
+
+        # only keep parsing for string if the current character matches the delim
+        if self._current != delim.value:
+            raise ValueError("Expecting a {!r} character".format(StringType.SLL))
+
+        # consume the opening delim, EOF here is an issue (middle of string)
+        self.inc(exception=UnexpectedEofError)
+
+        if self._current == delim.value:
+            # consume the second/closing delim, we do not care if EOF occurs as
+            # that would simply imply an empty single line string
+            if not self.inc() or self._current != delim.value:
+                # Empty string
+                return String(delim, "", "", Trivia())
+            else:
+                # consume the third delim, EOF here is an issue (middle of string)
+                self.inc(exception=UnexpectedEofError)
+
+                delim = delim.toggle()  # convert delim to multi delim
+
+        self.mark()  # to extract the original string with whitespace and all
         value = ""
 
-        if delim == "'":
-            str_type = StringType.SLL
-        else:
-            str_type = StringType.SLB
+        # A newline immediately following the opening delimiter will be trimmed.
+        if delim.is_multiline() and self._current == "\n":
+            # consume the newline, EOF here is an issue (middle of string)
+            self.inc(exception=UnexpectedEofError)
 
-        # Skip opening delim
-        if not self.inc():
-            return self.parse_error(UnexpectedEofError)
-
-        if self._current == delim:
-            self.inc()
-
-            if self._current == delim:
-                multiline = True
-                if delim == "'":
-                    str_type = StringType.MLL
-                else:
-                    str_type = StringType.MLB
-
-                if not self.inc():
-                    return self.parse_error(UnexpectedEofError)
-            else:
-                # Empty string
-                return String(str_type, "", "", Trivia())
-
-        self.mark()
-        if self._current == "\n":
-            # The first new line should be discarded
-            self.inc()
-
-        previous = None
-        escaped = False
+        ESCAPE = "\\"
+        escaped = False  # whether the previous key was ESCAPE
         while True:
-            if (
-                previous != "\\"
-                or previous == "\\"
-                and (escaped or str_type.is_literal())
-            ) and self._current == delim:
-                val = self.extract()
+            if not delim.is_multiline() and self._current.is_nl():
+                # single line cannot have actual newline characters
+                raise self.parse_error(UnexpectedEofError)
+            elif not escaped and self._current == delim.unit:
+                # try to process current as a closing delim
 
-                if multiline:
-                    stop = True
-                    for _ in range(3):
-                        if self._current != delim:
+                original = self.extract()
+
+                close = ""
+                if delim.is_multiline():
+                    # try consuming three delims as this would mean the end of
+                    # the string
+                    for last in [False, False, True]:
+                        if self._current != delim.unit:
                             # Not a triple quote, leave in result as-is.
-                            stop = False
-
-                            # Adding back the quote character
-                            value += delim
+                            # Adding back the characters we already consumed
+                            value += close
+                            close = ""  # clear the close
                             break
 
-                        self.inc()  # TODO: Handle EOF
+                        close += delim.unit
 
-                    if not stop:
+                        # consume this delim, EOF here is only an issue if this
+                        # is not the third (last) delim character
+                        self.inc(exception=UnexpectedEofError if not last else None)
+
+                    if not close:  # if there is no close characters, keep parsing
                         continue
                 else:
+                    close = delim.unit
+
+                    # consume the closing delim, we do not care if EOF occurs as
+                    # that would simply imply the end of self._src
                     self.inc()
 
-                return String(str_type, value, val, Trivia())
+                return String(delim, value, original, Trivia())
             else:
-                if previous == "\\" and self._current.is_ws() and multiline:
-                    while self._current.is_ws():
-                        previous = self._current
+                if delim.is_basic():
+                    if escaped:
+                        if delim.is_multiline() and self._current.is_ws():
+                            # we have an escape at the end of line inside of a
+                            # multiline, consume all of the whitespace up to the
+                            # next char
+                            # """\
+                            #     hello \
+                            #     world"""
+                            tmp = ""
+                            while self._current.is_ws():
+                                tmp += self._current
+                                # consume the whitespace, EOF here is an issue
+                                # (middle of string)
+                                self.inc(exception=UnexpectedEofError)
+                                continue
 
-                        self.inc()
-                        continue
-
-                    if self._current == delim:
-                        continue
-
-                if previous == "\\":
-                    if self._current == "\\" and not escaped:
-                        if not str_type.is_literal():
-                            escaped = True
-                        else:
-                            value += self._current
-
-                        previous = self._current
-
-                        if not self.inc():
-                            raise self.parse_error(UnexpectedEofError)
-
-                        continue
-                    elif self._current in _escaped and not escaped:
-                        if not str_type.is_literal():
-                            value = value[:-1]
-                            value += _escaped[self._current]
-                        else:
-                            value += self._current
-                    elif self._current in {"u", "U"} and not escaped:
-                        # Maybe unicode
-                        u, ue = self._peek_unicode(self._current == "U")
-                        if u is not None:
-                            value = value[:-1]
-                            value += u
-                            self.inc_n(len(ue))
-                        else:
-                            if not escaped and not str_type.is_literal():
+                            # the escape followed by whitespace must have a newline
+                            # before any other chars
+                            if "\n" not in tmp:
                                 raise self.parse_error(
                                     InvalidCharInStringError, (self._current,)
                                 )
+                        elif self._current in _escaped:
+                            # remove the previous (ESCAPE) and add the special character
+                            value += _escaped[self._current]
 
-                            value += self._current
-                    else:
-                        if not escaped and not str_type.is_literal():
+                            # consume this char, EOF here is an issue (middle of string)
+                            self.inc(exception=UnexpectedEofError)
+                        elif self._current in {"u", "U"}:
+                            # this needs to be a unicode
+                            u, ue = self._peek_unicode(self._current == "U")
+                            if u is not None:
+                                value += u
+                                # consume the U char and the unicode value
+                                self.inc_n(len(ue) + 1)
+                            else:
+                                raise self.parse_error(
+                                    InvalidCharInStringError, (self._current,)
+                                )
+                        else:
+                            # this char(s) is not escapable
                             raise self.parse_error(
                                 InvalidCharInStringError, (self._current,)
                             )
 
-                        value += self._current
-
-                    if self._current.is_ws() and multiline and not escaped:
+                        # no longer escaped
+                        escaped = False
                         continue
-                else:
-                    value += self._current
+                    elif self._current == ESCAPE:
+                        escaped = True  # the next char is being escaped
 
-                if escaped:
-                    escaped = False
+                        # consume this char, EOF here is an issue (middle of string)
+                        self.inc(exception=UnexpectedEofError)
 
-                previous = self._current
-                if not self.inc():
-                    raise self.parse_error(UnexpectedEofError)
+                        continue
 
-                if previous == "\\" and self._current.is_ws() and multiline:
-                    value = value[:-1]
+                # this is either a literal string where we keep everything as is,
+                # or this is not a special escaped char in a basic string
+                value += self._current
+
+                # consume this char, EOF here is an issue (middle of string)
+                self.inc(exception=UnexpectedEofError)
 
     def _parse_table(
         self, parent_name=None

--- a/tomlkit/toml_char.py
+++ b/tomlkit/toml_char.py
@@ -1,6 +1,12 @@
 import string
 
+from ._compat import PY2
 from ._compat import unicode
+
+if PY2:
+    from functools32 import lru_cache
+else:
+    from functools import lru_cache
 
 
 class TOMLChar(unicode):
@@ -10,36 +16,42 @@ class TOMLChar(unicode):
         if len(self) > 1:
             raise ValueError("A TOML character must be of length 1")
 
+    @lru_cache(maxsize=None)
     def is_bare_key_char(self):  # type: () -> bool
         """
         Whether the character is a valid bare key name or not.
         """
         return self in string.ascii_letters + string.digits + "-" + "_"
 
+    @lru_cache(maxsize=None)
     def is_kv_sep(self):  # type: () -> bool
         """
         Whether the character is a valid key/value separator ot not.
         """
         return self in "= \t"
 
+    @lru_cache(maxsize=None)
     def is_int_float_char(self):  # type: () -> bool
         """
         Whether the character if a valid integer or float value character or not.
         """
         return self in string.digits + "+" + "-" + "_" + "." + "e"
 
+    @lru_cache(maxsize=None)
     def is_ws(self):  # type: () -> bool
         """
         Whether the character is a whitespace character or not.
         """
         return self in " \t\r\n"
 
+    @lru_cache(maxsize=None)
     def is_nl(self):  # type: () -> bool
         """
         Whether the character is a new line character or not.
         """
         return self in "\n\r"
 
+    @lru_cache(maxsize=None)
     def is_spaces(self):  # type: () -> bool
         """
         Whether the character is a space or not


### PR DESCRIPTION
While reading through the string parsing I found that several cases were being missed or otherwise improperly implemented.

For example:

1. Newline characters in a string were being accepted within singleline strings:
    ```python
    import tomlkit
    tomlkit.parse('''
        this = "this
    that
    more"
    ''')
    # {'this': 'this\nthat\nmore'}
    ```
2. In parsing for a string's multiline closing delim we were accidentally consuming quotes when they weren't the closing delim:
    ```python
    import tomlkit
    tomlkit.parse('''
        this = """this
    ""
    more"""
    ''')
    # {'this': 'this\n"\nmore'}
    ```
3. The slashes at the end of a line were being handled incorrectly. According to [TOML](https://github.com/toml-lang/toml#string):
    > When the last non-whitespace character on a line is a `\`, it will be trimmed along with all whitespace (including newlines) up to the next non-whitespace character or closing delimiter.
    ```python
    import tomlkit
    tomlkit.parse('''
        this = """this \    more"""
    ''')
    # {'this': 'this more'}
    ```

These (and a few additional tests) have been added to the testing.

Other changes include:
- Caching (this is of debatable value so l can remove that if undesired)
- Worked to decrease code complexity of string parsing (hence the actual escape character parsing has been split out into a separate method
- Altered `Parser.inc()` to accept an `exception` argument, where when provided will raise the given exception at EOF (this helped to simplify string parsing, could be useful elsewhere)

Let me know if there are any additional changes that should be considered or changes here that should be reconsidered.