### PR TITLE
State Saver

### DIFF
--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -66,11 +66,11 @@ class _State:
         self.restore()
 
     def save(self):  # type: () -> None
-        self._index = self._src._index
+        self._idx = self._src._idx
         self._marker = self._src._marker
 
     def restore(self):  # type: () -> None
-        self._src.index = self._index
+        self._src.idx = self._idx
         if self._save_marker:
             self._src.marker = self._marker
 
@@ -104,24 +104,24 @@ class _Source(unicode):
         super(_Source, self).__init__()
         # Collection of TOMLChars
         self._chars = {}
-        self._index = 0
+        self._idx = 0
         self._marker = 0
 
     @property
-    def index(self):  # type: () -> int
-        return self._index
+    def idx(self):  # type: () -> int
+        return self._idx
 
-    @index.setter
-    def index(self, index):  # type: (int) -> None
-        index = int(index)
-        assert index >= 0
-        assert index <= len(self)
-        self._index = index
+    @idx.setter
+    def idx(self, idx):  # type: (int) -> None
+        idx = int(idx)
+        assert idx >= 0
+        assert idx <= len(self)
+        self._idx = idx
 
     @property
     def current(self):  # type: () -> TOMLChar
         try:
-            return self[self._index]
+            return self[self._idx]
         except IndexError:
             return self.EOF
 
@@ -130,11 +130,11 @@ class _Source(unicode):
         return self._marker
 
     @marker.setter
-    def marker(self, index):  # type: (int) -> None
-        index = int(index)
-        assert index >= 0
-        assert index < len(self)
-        self._marker = index
+    def marker(self, idx):  # type: (int) -> None
+        idx = int(idx)
+        assert idx >= 0
+        assert idx < len(self)
+        self._marker = idx
 
     def __getitem__(
         self, item
@@ -154,7 +154,7 @@ class _Source(unicode):
         """
         Extracts the value between marker and index
         """
-        return self[self._marker : self._index]
+        return self[self._marker : self._idx]
 
     def inc(self, exception=None):  # type: (Exception) -> bool
         """
@@ -162,11 +162,11 @@ class _Source(unicode):
         Returns whether or not it was able to advance.
         """
         # only increment index if we are not at the last index yet
-        if self._index < (len(self) - 1):
-            self._index += 1
+        if self._idx < (len(self) - 1):
+            self._idx += 1
             return True
 
-        self._index = len(self)
+        self._idx = len(self)
         if exception:
             raise exception
         return False
@@ -186,13 +186,13 @@ class _Source(unicode):
         """
         Returns True if the parser has reached the end of the input.
         """
-        return self._index >= len(self)
+        return self._idx >= len(self)
 
     def mark(self):  # type: () -> None
         """
         Sets the marker to the index's current position
         """
-        self._marker = self._index
+        self._marker = self._idx
 
 
 class Parser:
@@ -211,7 +211,7 @@ class Parser:
 
     @property
     def _idx(self):
-        return self._src.index
+        return self._src.idx
 
     @property
     def _current(self):

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -82,7 +82,7 @@ class _State:
         self._source._idx = self._idx
         self._source._current = self._current
         if self._save_marker:
-            self._source.marker = self._marker
+            self._source._marker = self._marker
 
 
 class _StateHandler:
@@ -132,7 +132,7 @@ class _Source(unicode):
 
     @property
     def current(self):  # type: () -> TOMLChar
-        self._current
+        return self._current
 
     @property
     def marker(self):  # type: () -> int
@@ -151,6 +151,7 @@ class _Source(unicode):
         """
         try:
             self._idx, self._current = next(self._chars)
+            return True
         except StopIteration:
             self._idx = len(self)
             self._current = self.EOF

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -51,9 +51,11 @@ from .toml_document import TOMLDocument
 
 
 class _State:
-    def __init__(self, parser, marker=False):  # type: (Parser, Optional[bool]) -> None
+    def __init__(
+        self, parser, save_marker=False
+    ):  # type: (Parser, Optional[bool]) -> None
         self._src = parser._src
-        self._save_marker = marker
+        self._save_marker = save_marker
 
     def __enter__(self):  # type: () -> None
         # Entering this context manager - save the state
@@ -82,8 +84,8 @@ class _StateHandler:
         self._parser = parser
         self._states = []
 
-    def __call__(self, marker=False):
-        return _State(parser=self._parser, marker=marker)
+    def __call__(self, save_marker=False):
+        return _State(parser=self._parser, save_marker=save_marker)
 
     def __enter__(self):  # type: () -> None
         state = self()
@@ -1088,7 +1090,7 @@ class Parser:
         Returns the name of the table about to be parsed,
         as well as whether it is part of an AoT.
         """
-        with self._state(marker=True):
+        with self._state(save_marker=True):
             if self._current != "[":
                 raise self.parse_error(
                     InternalParserError,
@@ -1152,7 +1154,7 @@ class Parser:
 
         Returns the unicode value is it's a valid one else None.
         """
-        with self._state(marker=True):
+        with self._state(save_marker=True):
             if self._current not in {"u", "U"}:
                 raise self.parse_error(
                     InternalParserError,


### PR DESCRIPTION
Simplified state saving/restoring.

Previously:

```python
idx = self._save_idx()

# do peeking here
...

self._restore_idx(*idx)
```

Now:

```python
with self._src.state:
    # do peeking here
    ...
```

And in cases where the marker also needs to be preserved:

```python
with self._src.state(save_marker=True):
    # do peeking here
    ...
```

A bonus feature that may become valuable for number versus date parsing is the ability to save multiple states:

```python
with self._src.state:
    # do some peeking here
    ...
    with self._src.state:
        # do some more peeking here
        ...
```