### PR TITLE
Trim comments when setting InlineTable

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -424,5 +424,7 @@ def test_trim_comments_when_building_inline_table():
     row = parse('foo = "bar"  # Comment')
     table.update(row)
     assert table.as_string() == '{foo = "bar"}'
-    table.append("baz", row["foo"])
-    assert "# Comment" not in table.as_string()
+    value = item("foobaz")
+    value.comment("Another comment")
+    table.append("baz", value)
+    assert "# Another comment" not in table.as_string()

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -417,3 +417,12 @@ def test_items_are_pickable():
 
     s = pickle.dumps(n)
     assert pickle.loads(s).as_string() == 'foo = "bar"\n'
+
+
+def test_trim_comments_when_building_inline_table():
+    table = inline_table()
+    row = parse('foo = "bar"  # Comment')
+    table.update(row)
+    assert table.as_string() == '{foo = "bar"}'
+    table.append("baz", row["foo"])
+    assert "# Comment" not in table.as_string()

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -942,6 +942,8 @@ class InlineTable(Item, dict):
         if not isinstance(_item, (Whitespace, Comment)):
             if not _item.trivia.indent and len(self._value) > 0:
                 _item.trivia.indent = " "
+            if _item.trivia.comment:
+                _item.trivia.comment = ""
 
         self._value.append(key, _item)
 
@@ -1021,6 +1023,8 @@ class InlineTable(Item, dict):
 
         if key is not None:
             super(InlineTable, self).__setitem__(key, value)
+        if value.trivia.comment:
+            value.trivia.comment = ""
 
         m = re.match("(?s)^[^ ]*([ ]+).*$", self._trivia.indent)
         if not m:


### PR DESCRIPTION
InlineTable is supposed to be one liner and doesn't support comments in values.

Closes #30 