### PR TITLE
Pick the max when there are many indices for a key.

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -113,3 +113,18 @@ def test_add_remove():
     doc.remove("foo")
 
     assert doc.as_string() == ""
+
+
+def test_append_table_after_multiple_indices():
+    content = """
+    [packages]
+    foo = "*"
+
+    [settings]
+    enable = false
+
+    [packages.bar]
+    version = "*"
+    """
+    doc = parse(content)
+    doc.append("foobar", {"name": "John"})

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -247,6 +247,9 @@ class Container(dict):
         item = _item(item)
 
         idx = self._map[key]
+        # Insert after the max index if there are many.
+        if isinstance(idx, tuple):
+            idx = max(idx)
         current_item = self._body[idx][1]
         if "\n" not in current_item.trivia.trail:
             current_item.trivia.trail += "\n"


### PR DESCRIPTION
The test case demonstrates how it fails when appending a table.