### PR TITLE
inline tables should have newlines after them

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 
 from tomlkit import inline_table
 from tomlkit import parse
+from tomlkit import dumps
 from tomlkit._compat import PY2
 from tomlkit.exceptions import NonExistentKey
 from tomlkit.items import InlineTable
@@ -429,6 +430,19 @@ def test_trim_comments_when_building_inline_table():
     table.append("baz", value)
     assert "# Another comment" not in table.as_string()
     assert '{foo = "bar", baz = "foobaz"}' == table.as_string()
+
+
+def test_inline_table_should_append_a_newline():
+    content = "[foo]\nh = 1\n[bar]\nc = 2\n"
+
+    doc = parse(content)
+    insert = inline_table()
+    insert['z'] = 3
+    doc['foo']['added'] = insert
+    
+    result = dumps(doc)
+
+    assert "}[" not in result
 
 
 def test_deleting_inline_table_elemeent_does_not_leave_trailing_separator():

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -437,9 +437,9 @@ def test_inline_table_should_append_a_newline():
 
     doc = parse(content)
     insert = inline_table()
-    insert['z'] = 3
-    doc['foo']['added'] = insert
-    
+    insert["z"] = 3
+    doc["foo"]["added"] = insert
+
     result = dumps(doc)
 
     assert "}[" not in result

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -19,6 +19,7 @@ from .items import Item
 from .items import Key
 from .items import Null
 from .items import Table
+from .items import InlineTable
 from .items import Whitespace
 from .items import item as _item
 
@@ -100,6 +101,9 @@ class Container(dict):
             and not item.trivia.indent
         ):
             item.trivia.indent = "\n"
+
+        if isinstance(item, InlineTable) and self._body and not self._parsed:
+            self.append(None, Whitespace("\n"))
 
         if isinstance(item, AoT) and self._body and not self._parsed:
             if item and "\n" not in item[0].trivia.indent:


### PR DESCRIPTION
I noticed after adding and removing some dependencies with extras, that newlines were disappaering in my pyproject.toml.  I tracked it down to inline_tables not including newlines.  I'm not really familiar with the codebase, so this fix may leave other gaps  but I think it addresses a common pattern.

included are:

  -proposed fix
  -test case

You can see a realworld example of this bug by running this sequence a few times on a healthy pyproject.toml file

poetry add  -E bcrypt -E argon2 passlib
poetry remove  passlib
