### PR TITLE
Fix string output order for out of order tables

### DIFF
--- a/tests/examples/json/pyproject.json
+++ b/tests/examples/json/pyproject.json
@@ -97,5 +97,11 @@
                 "foo": "bar"
             }
         ]
+    },
+    "build-system": {
+        "requires": [
+            "poetry-core>=1.0.0a3"
+        ],
+        "build-backend": "poetry.core.masonry.api"
     }
 }

--- a/tests/examples/pyproject.toml
+++ b/tests/examples/pyproject.toml
@@ -61,6 +61,11 @@ tox = "^3.0"
 poetry = "poetry.console:main"
 
 
+[build-system]
+requires = ["poetry-core>=1.0.0a3"]
+build-backend = "poetry.core.masonry.api"
+
+
 [tool.black]
 line-length = 88
 py36 = true

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -569,3 +569,50 @@ key = "value"
 
     with pytest.raises(KeyError):
         table.pop("missing")
+
+
+def test_string_output_order_is_preserved_for_out_of_order_tables():
+    content = """
+[tool.poetry]
+name = "foo"
+
+[tool.poetry.dependencies]
+python = "^3.6"
+bar = "^1.0"
+
+
+[build-system]
+requires = ["poetry-core"]
+backend = "poetry.core.masonry.api"
+
+
+[tool.other]
+a = "b"
+"""
+
+    doc = parse(content)
+    constraint = tomlkit.inline_table()
+    constraint["version"] = "^1.0"
+    doc["tool"]["poetry"]["dependencies"]["bar"] = constraint
+
+    assert "^1.0" == doc["tool"]["poetry"]["dependencies"]["bar"]["version"]
+
+    expected = """
+[tool.poetry]
+name = "foo"
+
+[tool.poetry.dependencies]
+python = "^3.6"
+bar = {version = "^1.0"}
+
+
+[build-system]
+requires = ["poetry-core"]
+backend = "poetry.core.masonry.api"
+
+
+[tool.other]
+a = "b"
+"""
+
+    assert expected == doc.as_string()

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -293,6 +293,9 @@ class Item(object):
     def is_inline_table(self):  # type: () -> bool
         return isinstance(self, InlineTable)
 
+    def is_aot(self):  # type: () -> bool
+        return isinstance(self, AoT)
+
     def _getstate(self, protocol=3):
         return (self._trivia,)
 


### PR DESCRIPTION
Whenever tables were out of orders the tables were not necessarily dumped in the original order.

This PR fixes it.