### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [0.7.0] - 2020-07-31
+
+### Added
+
+- Added support for sorting keys when dumping raw dictionaries by passing `sort_keys=True` to `dumps()` ([#103](https://github.com/sdispater/tomlkit/pull/103)).
+
+### Changed
+
+- Keys are not longer sorted by default when dumping a raw dictionary but the original order will be preserved ([#103](https://github.com/sdispater/tomlkit/pull/103)).
+
+### Fixed
+
+- Fixed compliance with the 1.0.0rc1 TOML specification ([#102](https://github.com/sdispater/tomlkit/pull/102)).
+
+
 ## [0.6.0] - 2020-04-15
 
 ### Added
@@ -190,7 +205,8 @@
 - Fixed raw strings escaping.
 
 
-[Unreleased]: https://github.com/sdispater/tomlkit/compare/0.6.0...master
+[Unreleased]: https://github.com/sdispater/tomlkit/compare/0.7.0...master
+[0.7.0]: https://github.com/sdispater/tomlkit/releases/tag/0.7.0
 [0.6.0]: https://github.com/sdispater/tomlkit/releases/tag/0.6.0
 [0.5.11]: https://github.com/sdispater/tomlkit/releases/tag/0.5.11
 [0.5.10]: https://github.com/sdispater/tomlkit/releases/tag/0.5.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tomlkit"
-version = "0.6.0"
+version = "0.7.0"
 description = "Style preserving TOML library"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"

--- a/tomlkit/__init__.py
+++ b/tomlkit/__init__.py
@@ -22,4 +22,4 @@ from .api import value
 from .api import ws
 
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
### Added

- Added support for sorting keys when dumping raw dictionaries by passing `sort_keys=True` to `dumps()` ([#103](https://github.com/sdispater/tomlkit/pull/103)).

### Changed

- Keys are not longer sorted by default when dumping a raw dictionary but the original order will be preserved ([#103](https://github.com/sdispater/tomlkit/pull/103)).

### Fixed

- Fixed compliance with the 1.0.0rc1 TOML specification ([#102](https://github.com/sdispater/tomlkit/pull/102)).