### PR TITLE
Add support for toml files in UTF8 with BOM

### DIFF
--- a/tests/examples/utf8_with_bom.toml
+++ b/tests/examples/utf8_with_bom.toml
@@ -1,0 +1,1 @@
+﻿format = "格式：UTF-8 Unicode (with BOM)"

--- a/tests/test_toml_file.py
+++ b/tests/test_toml_file.py
@@ -1,6 +1,9 @@
 import io
 import os
 
+import pytest
+
+from tomlkit.exceptions import EmptyKeyError
 from tomlkit.toml_document import TOMLDocument
 from tomlkit.toml_file import TOMLFile
 
@@ -23,3 +26,11 @@ def test_toml_file(example):
     finally:
         with io.open(toml_file, "w", encoding="utf-8") as f:
             assert f.write(original_content)
+
+
+def test_toml_file_in_utf8_with_bom_format():
+    toml_file = os.path.join(os.path.dirname(__file__), "examples", "utf8_with_bom.toml")
+    try:
+        TOMLFile(toml_file).read()
+    except EmptyKeyError:
+        pytest.fail("Unexpected EmptyKeyError ...")

--- a/tomlkit/toml_file.py
+++ b/tomlkit/toml_file.py
@@ -16,7 +16,7 @@ class TOMLFile(object):
         self._path = path
 
     def read(self):  # type: () -> TOMLDocument
-        with io.open(self._path, encoding="utf-8") as f:
+        with io.open(self._path, encoding="utf-8-sig") as f:
             return loads(f.read())
 
     def write(self, data):  # type: (TOMLDocument) -> None


### PR DESCRIPTION
Throw tomlkit.exceptions.EmptyKeyError from TOMLFile.read for a toml file in UTF8 with BOM. 

BTW, UTF8 file in Windows is with BOM by default.