### PR TITLE
Add a py.typed file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ packages = [
     {include = "tomlkit"},
     {include = "tests", format = "sdist"}
 ]
+include = ["tomlkit/py.typed"]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"


### PR DESCRIPTION
Without a `py.typed` file, mypy won't pick up the type hint comments.