### PR TITLE
Fix incorrect InvalidControlChar error message

### DIFF
--- a/tomlkit/exceptions.py
+++ b/tomlkit/exceptions.py
@@ -211,7 +211,7 @@ class InvalidControlChar(ParseError):
         if char < 16:
             display_code += "0"
 
-        display_code += str(char)
+        display_code += hex(char)[2:]
 
         message = (
             "Control characters (codes less than 0x1f and 0x7f) are not allowed in {}, "


### PR DESCRIPTION
TOML `\u` unicode literal takes a hex string, but the error message was using `str()`. This results in an incorrect suggestion to users.