### PR TITLE
Remove "tests" package from sdist installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,9 @@ repository = "https://github.com/sdispater/tomlkit"
 
 packages = [
     {include = "tomlkit"},
-    {include = "tests", format = "sdist"}
 ]
+
+include = ["tests"]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
     {include = "tomlkit"},
 ]
 
-include = ["tests"]
+include = [{ path = "tests", format = "sdist" }]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"


### PR DESCRIPTION
Resolves #69 (nice).  Currently the tomlkit tests are included in the distribution via `packages`, but that behavior is incorrect since it causes `tests` to be exposed (and installed!) as a module.  We don't want that; we only want `tests` to be _included_ in the source distribution, so the more sensible configuration is to use the `include` key.

Solution comes from [this comment](https://github.com/python-poetry/poetry/issues/2353#issuecomment-578438198), as well as [@abn's implementation of the same fix for Poetry](https://github.com/python-poetry/poetry/pull/4007).
