### PR TITLE
Correctly restore data for container

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -669,3 +669,16 @@ inline = {"foo" = "bar", "bar" = "baz"}
     )
 
     assert repr(doc["namespace"]) == "{'key1': 'value1', 'key2': 'value2'}"
+
+
+def test_deepcopy():
+    content = """
+[tool]
+name = "foo"
+[tool.project.section]
+option = "test"
+"""
+    doc = parse(content)
+    copied = copy.deepcopy(doc)
+    assert copied == doc
+    assert copied.as_string() == content

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -654,13 +654,18 @@ class Container(MutableMapping, dict):
         return (
             self.__class__,
             self._getstate(protocol),
-            (self._map, self._body, self._parsed),
+            (self._map, self._body, self._parsed, self._table_keys),
         )
 
     def __setstate__(self, state):
         self._map = state[0]
         self._body = state[1]
         self._parsed = state[2]
+        self._table_keys = state[3]
+        
+        for key, item in self._body:
+            if key is not None:
+                dict.__setitem__(self, key.key, item.value)
 
     def copy(self):  # type: () -> Container
         return copy.copy(self)

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -662,7 +662,7 @@ class Container(MutableMapping, dict):
         self._body = state[1]
         self._parsed = state[2]
         self._table_keys = state[3]
-        
+
         for key, item in self._body:
             if key is not None:
                 dict.__setitem__(self, key.key, item.value)


### PR DESCRIPTION
When reconstructing the container, make sure data are set to the internal `dict`.

Fixes #124 