### PR TITLE
Expose public class in type hints for dumps/loads (#130)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,6 +128,15 @@ def test_a_raw_dict_can_be_dumped():
     assert s == 'foo = "bar"\n'
 
 
+def test_mapping_types_can_be_dumped():
+    try:
+        from types import MappingProxyType
+        x = MappingProxyType({"foo": "bar"})
+        assert dumps(x) == 'foo = "bar"\n'
+    except ImportError:
+        pytest.skip("requires Python > 3.3")
+
+
 def test_integer():
     i = tomlkit.integer("34")
 

--- a/tomlkit/__init__.py
+++ b/tomlkit/__init__.py
@@ -20,6 +20,7 @@ from .api import table
 from .api import time
 from .api import value
 from .api import ws
+from .api import TOMLDocument
 
 
 __version__ = "0.7.2"

--- a/tomlkit/_compat.py
+++ b/tomlkit/_compat.py
@@ -156,9 +156,9 @@ else:
     from collections import OrderedDict
 
 try:
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping, MutableMapping
 except ImportError:
-    from collections import MutableMapping
+    from collections import Mapping, MutableMapping
 
 
 def decode(string, encodings=None):

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -2,6 +2,7 @@ import datetime as _datetime
 
 from typing import Tuple
 
+from ._compat import Mapping
 from ._utils import parse_rfc3339
 from .container import Container
 from .items import AoT
@@ -22,10 +23,10 @@ from .items import Trivia
 from .items import Whitespace
 from .items import item
 from .parser import Parser
-from .toml_document import TOMLDocument as _TOMLDocument
+from .toml_document import TOMLDocument
 
 
-def loads(string):  # type: (str) -> _TOMLDocument
+def loads(string):  # type: (str) -> TOMLDocument
     """
     Parses a string into a TOMLDocument.
 
@@ -34,28 +35,28 @@ def loads(string):  # type: (str) -> _TOMLDocument
     return parse(string)
 
 
-def dumps(data, sort_keys=False):  # type: (_TOMLDocument, bool) -> str
+def dumps(data, sort_keys=False):  # type: (Mapping, bool) -> str
     """
     Dumps a TOMLDocument into a string.
     """
-    if not isinstance(data, _TOMLDocument) and isinstance(data, dict):
-        data = item(data, _sort_keys=sort_keys)
+    if not isinstance(data, Container) and isinstance(data, Mapping):
+        data = item(dict(data), _sort_keys=sort_keys)
 
     return data.as_string()
 
 
-def parse(string):  # type: (str) -> _TOMLDocument
+def parse(string):  # type: (str) -> TOMLDocument
     """
     Parses a string into a TOMLDocument.
     """
     return Parser(string).parse()
 
 
-def document():  # type: () -> _TOMLDocument
+def document():  # type: () -> TOMLDocument
     """
     Returns a new TOMLDocument instance.
     """
-    return _TOMLDocument()
+    return TOMLDocument()
 
 
 # Items


### PR DESCRIPTION
Hello, this is an attempt to solve #130.

Unfortunately, I had lots of trouble trying to run the test suite locally (with both `tox` and ``poetry run pytest tests/`), so sorry for advance if something goes wrong (what I ended up doing was firing up a python terminal, loading the `test_api` file and manually running `test_mapping_types_can_be_dumped()`.