### PR TITLE
raise error on missing "="

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,7 @@ import pytest
 
 from tomlkit.exceptions import EmptyTableNameError
 from tomlkit.exceptions import InternalParserError
+from tomlkit.exceptions import UnexpectedCharError
 from tomlkit.items import StringType
 from tomlkit.parser import Parser
 
@@ -30,3 +31,17 @@ def test_parser_should_raise_an_error_for_empty_tables():
 
     assert e.value.line == 4
     assert e.value.col == 1
+
+def test_parser_should_raise_an_error_for_missing_eq_before_inline_table():
+    content = """
+[a]
+b {c = "d"}
+"""
+
+    parser = Parser(content)
+
+    with pytest.raises(UnexpectedCharError) as e:
+        parser.parse()
+
+    assert e.value.line == 3
+    assert e.value.col == 2

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -387,6 +387,10 @@ class Parser:
                 else:
                     found_equals = True
             pass
+        
+        # If we didn't find an "=", it's not valid TOML.
+        if not found_equals:
+            raise self.parse_error(UnexpectedCharError, self._current)
 
         if not key.sep:
             key.sep = self.extract()


### PR DESCRIPTION
fixes #141

Luckily, we already tracked whether an `=` was present to prevent duplicate `=`'s.  This only parses successfully on _exactly one_ `=`.