### PR TITLE
Add an argument to allow table to be super table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased]
+
+### Changed
+
+- Add a new argument to `table` API to allow it to be a super table. ([#159](https://github.com/sdispater/tomlkit/pull/159))
+
 ## [0.8.0] - 2021-12-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - Add a new argument to `table` API to allow it to be a super table. ([#159](https://github.com/sdispater/tomlkit/pull/159))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -283,3 +283,11 @@ def test_item_mixed_aray():
     t = tomlkit.item(example)
     assert t.as_string().strip() == expected
     assert dumps({"x": {"y": example}}).strip() == "[x]\ny = " + expected
+
+
+def test_build_super_table():
+    doc = tomlkit.document()
+    table = tomlkit.table(True)
+    table.add("bar", {"x": 1})
+    doc.add("foo", table)
+    assert doc.as_string() == "[foo.bar]\nx = 1\n"

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -129,8 +129,8 @@ def array(raw: str = None) -> Array:
     return value(raw)
 
 
-def table() -> Table:
-    return Table(Container(), Trivia(), False)
+def table(is_super_table: bool = False) -> Table:
+    return Table(Container(), Trivia(), False, is_super_table)
 
 
 def inline_table() -> InlineTable:


### PR DESCRIPTION
```python
doc = tomlkit.document()
table = tomlkit.table(True)
table.add("bar", {"x": 1})
doc.add("foo", table)
print(doc.as_string())
```
```toml
[foo.bar]
x = 1
```
Intermediate table is hidden.

Fixes #47 