### PR TITLE
Fix values similar to booleans being incorrectly parsed to booleans

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -307,3 +307,12 @@ def test_add_dotted_key():
 def test_value_parses_boolean(raw, expected):
     parsed = tomlkit.value(raw)
     assert parsed == expected
+
+
+@pytest.mark.parametrize(
+    "raw", ["t", "f", "tru", "fals", "test", "friend", "truthy", "falsify"]
+)
+def test_value_rejects_values_looking_like_bool_at_start(raw):
+    """Reproduces https://github.com/sdispater/tomlkit/issues/165"""
+    with pytest.raises(tomlkit.exceptions.ParseError):
+        tomlkit.value(raw)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -308,8 +308,6 @@ def test_add_dotted_key():
     [
         ("true", True),
         ("false", False),
-        ("true ", True),
-        ("false ", False),
     ],
 )
 def test_value_parses_boolean(raw, expected):
@@ -352,5 +350,27 @@ def test_value_rejects_values_having_true_prefix(raw):
 )
 def test_value_rejects_values_having_false_prefix(raw):
     """Values that have ``true`` or ``false`` as prefix but then have additional chars are rejected."""
+    with pytest.raises(tomlkit.exceptions.ParseError):
+        tomlkit.value(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '"foo"1.2',
+        "truefalse",
+        "1.0false",
+        "100true",
+        "truetrue",
+        "falsefalse",
+        "1.2.3.4",
+        "[][]",
+        "{a=[][]}[]",
+        "true[]",
+        "false{a=1}",
+    ],
+)
+def test_value_rejects_values_with_appendage(raw):
+    """Values that appear valid at the beginning but leave chars unparsed are rejected."""
     with pytest.raises(tomlkit.exceptions.ParseError):
         tomlkit.value(raw)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -303,7 +303,15 @@ def test_add_dotted_key():
     assert table.as_string() == "foo.bar = 1\n"
 
 
-@pytest.mark.parametrize(("raw", "expected"), [("true", True), ("false", False)])
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("true", True),
+        ("false", False),
+        ("true ", True),
+        ("false ", False),
+    ],
+)
 def test_value_parses_boolean(raw, expected):
     parsed = tomlkit.value(raw)
     assert parsed == expected
@@ -314,5 +322,35 @@ def test_value_parses_boolean(raw, expected):
 )
 def test_value_rejects_values_looking_like_bool_at_start(raw):
     """Reproduces https://github.com/sdispater/tomlkit/issues/165"""
+    with pytest.raises(tomlkit.exceptions.ParseError):
+        tomlkit.value(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "truee",
+        "truely",
+        "true-thoughts",
+        "true_hip_hop",
+    ],
+)
+def test_value_rejects_values_having_true_prefix(raw):
+    """Values that have ``true`` or ``false`` as prefix but then have additional chars are rejected."""
+    with pytest.raises(tomlkit.exceptions.ParseError):
+        tomlkit.value(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "falsee",
+        "falsely",
+        "false-ideas",
+        "false_prophet",
+    ],
+)
+def test_value_rejects_values_having_false_prefix(raw):
+    """Values that have ``true`` or ``false`` as prefix but then have additional chars are rejected."""
     with pytest.raises(tomlkit.exceptions.ParseError):
         tomlkit.value(raw)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -301,3 +301,9 @@ def test_add_dotted_key():
     table = tomlkit.table()
     table.add(tomlkit.key(["foo", "bar"]), 1)
     assert table.as_string() == "foo.bar = 1\n"
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("true", True), ("false", False)])
+def test_value_parses_boolean(raw, expected):
+    parsed = tomlkit.value(raw)
+    assert parsed == expected

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -8,6 +8,7 @@ from typing import Union
 
 from ._utils import parse_rfc3339
 from .container import Container
+from .exceptions import UnexpectedCharError
 from .items import AoT
 from .items import Array
 from .items import Bool
@@ -232,7 +233,11 @@ def value(raw: str) -> _Item:
     >>> value("[1, 2, 3]")
     [1, 2, 3]
     """
-    return Parser(raw)._parse_value()
+    parser = Parser(raw)
+    v = parser._parse_value()
+    if not parser.end():
+        raise parser.parse_error(UnexpectedCharError, char=parser._current)
+    return v
 
 
 def key_value(src: str) -> Tuple[Key, _Item]:

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -424,9 +424,16 @@ class Parser:
             return self._parse_basic_string()
         elif c == StringType.SLL.value:
             return self._parse_literal_string()
-        elif c == BoolType.TRUE.value[0]:
+        # peek one furhter then the value so we don't parse values that look like trueXXX or falseXXX
+        elif (
+            c == BoolType.TRUE.value[0]
+            and self._peek(len(BoolType.TRUE.value) + 1) == BoolType.TRUE.value
+        ):
             return self._parse_true()
-        elif c == BoolType.FALSE.value[0]:
+        elif (
+            c == BoolType.FALSE.value[0]
+            and self._peek(len(BoolType.FALSE.value) + 1) == BoolType.FALSE.value
+        ):
             return self._parse_false()
         elif c == "[":
             return self._parse_array()
@@ -1082,7 +1089,7 @@ class Parser:
         with self._state(restore=True):
             buf = ""
             for _ in range(n):
-                if self._current not in " \t\n\r#,]}":
+                if self._current not in " \t\n\r#,]}" + self._src.EOF:
                     buf += self._current
                     self.inc()
                     continue

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -123,11 +123,11 @@ class Parser:
         """
         self._src.mark()
 
-    def parse_error(self, exception=ParseError, *args):
+    def parse_error(self, exception=ParseError, *args, **kwargs):
         """
         Creates a generic "parse error" at the current position.
         """
-        return self._src.parse_error(exception, *args)
+        return self._src.parse_error(exception, *args, **kwargs)
 
     def parse(self) -> TOMLDocument:
         body = TOMLDocument(True)
@@ -424,16 +424,9 @@ class Parser:
             return self._parse_basic_string()
         elif c == StringType.SLL.value:
             return self._parse_literal_string()
-        # peek one furhter then the value so we don't parse values that look like trueXXX or falseXXX
-        elif (
-            c == BoolType.TRUE.value[0]
-            and self._peek(len(BoolType.TRUE.value) + 1) == BoolType.TRUE.value
-        ):
+        elif c == BoolType.TRUE.value[0]:
             return self._parse_true()
-        elif (
-            c == BoolType.FALSE.value[0]
-            and self._peek(len(BoolType.FALSE.value) + 1) == BoolType.FALSE.value
-        ):
+        elif c == BoolType.FALSE.value[0]:
             return self._parse_false()
         elif c == "[":
             return self._parse_array()

--- a/tomlkit/source.py
+++ b/tomlkit/source.py
@@ -147,7 +147,7 @@ class Source(str):
 
         # failed to consume minimum number of characters
         if min > 0:
-            self.parse_error(UnexpectedCharError, self.current)
+            raise self.parse_error(UnexpectedCharError, self.current)
 
     def end(self) -> bool:
         """

--- a/tomlkit/source.py
+++ b/tomlkit/source.py
@@ -162,14 +162,17 @@ class Source(str):
         self._marker = self._idx
 
     def parse_error(
-        self, exception: Type[ParseError] = ParseError, *args: Any
+        self,
+        exception: Type[ParseError] = ParseError,
+        *args: Any,
+        **kwargs: Any,
     ) -> ParseError:
         """
         Creates a generic "parse error" at the current position.
         """
         line, col = self._to_linecol()
 
-        return exception(line, col, *args)
+        return exception(line, col, *args, **kwargs)
 
     def _to_linecol(self) -> Tuple[int, int]:
         cur = 0


### PR DESCRIPTION
This included values that strat with `t` or `f` like `test` and `friend` as well as values that have `true` or `false` as prefix like `truely` and `falsely`.

All of them are now incorrectly rejected by `tomlkit.value`.

Closes #165 