### PR TITLE
Allow string type to be controlled from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Fix the only child detection when creating tables. ([#175](https://github.com/sdispater/tomlkit/issues/175))
 - Include the `docs/` directory and `CHANGELOG.md` in sdist tarball. ([#176](https://github.com/sdispater/tomlkit/issues/176))
 
+### Added
+
+- Add keyword arguments to `string` API to allow selecting the representation type. ([#177](https://github.com/sdispater/tomlkit/pull/177))
+
 ## [0.9.2] - 2022-02-08
 
 ### Changed

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -412,6 +412,7 @@ def test_create_string_with_different_types(kwargs, example, expected):
     "kwargs, example, expected",
     [
         ({}, "My\nString\u0001", '"My\\nString\\u0001"'),
+        ({"literal": True}, "My'String", "'My\\u0027String'"),
         ({"escape": False}, "My String\u0001", '"My String\u0001"'),
         ({"escape": False, "literal": True}, "My'String", "'My'String'"),
         ({"multiline": True}, 'My"""String', '"""My""\\"String"""'),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -405,9 +405,9 @@ def test_create_super_table_with_aot():
         (
             {"multiline": True, "single_quotes": True, "escape": True},
             "My\nString",
-            "'''My\\nString'''"
+            "'''My\\nString'''",
         ),
-    ]
+    ],
 )
 def test_create_string_with_different_types(kwargs, example, expected):
     value = tomlkit.string(example, **kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -392,3 +392,23 @@ def test_create_super_table_with_table():
 def test_create_super_table_with_aot():
     data = {"foo": {"bar": [{"a": 1}]}}
     assert dumps(data) == "[[foo.bar]]\na = 1\n"
+
+
+@pytest.mark.parametrize(
+    "kwargs, example, expected",
+    [
+        ({}, "My\nString\u0001", '"My\\nString\\u0001"'),
+        ({"escape": False}, "My String\u0001", '"My String\u0001"'),
+        ({"single_quotes": True}, "My\nString", "'My\\nString'"),
+        ({"multiline": True}, "\nMy\nString\n", '"""\nMy\nString\n"""'),
+        ({"multiline": True, "single_quotes": True}, "My\nString", "'''My\nString'''"),
+        (
+            {"multiline": True, "single_quotes": True, "escape": True},
+            "My\nString",
+            "'''My\\nString'''"
+        ),
+    ]
+)
+def test_create_string_with_different_types(kwargs, example, expected):
+    value = tomlkit.string(example, **kwargs)
+    assert value.as_string() == expected

--- a/tomlkit/_utils.py
+++ b/tomlkit/_utils.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 from datetime import timezone
+from typing import Collection
 from typing import Union
 
 from ._compat import decode
@@ -97,31 +98,57 @@ def parse_rfc3339(string: str) -> Union[datetime, date, time]:
     raise ValueError("Invalid RFC 339 string")
 
 
-_escaped = {"b": "\b", "t": "\t", "n": "\n", "f": "\f", "r": "\r", '"': '"', "\\": "\\"}
-_escapes = {v: k for k, v in _escaped.items()}
+# https://toml.io/en/v1.0.0#string
+CONTROL_CHARS = frozenset(chr(c) for c in range(0x20)) | {chr(0x7F)}
+_escaped = {
+    "b": "\b",
+    "t": "\t",
+    "n": "\n",
+    "f": "\f",
+    "r": "\r",
+    '"': '"',
+    "\\": "\\",
+}
+_compact_escapes = {v: k for k, v in _escaped.items()}
+_basic_escapes = frozenset(CONTROL_CHARS | {'"', "\\"})
+_escaped_sequences = {
+    '"""': '""\\"',
+    "'''": "''\\'",
+}
 
 
-def escape_string(s: str) -> str:
+def escape_string(
+    s: str,
+    escape_chars: Collection[str] = _basic_escapes,
+    escape_sequences: Collection[str] = (),
+) -> str:
     s = decode(s)
 
     res = []
     start = 0
+    l = len(s)
 
-    def flush():
+    def flush(inc=1):
         if start != i:
             res.append(s[start:i])
 
-        return i + 1
+        return i + inc
 
     i = 0
-    while i < len(s):
+    while i < l:
         c = s[i]
-        if c in '"\\\n\r\t\b\f':
+        if c in escape_chars:
             start = flush()
-            res.append("\\" + _escapes[c])
-        elif ord(c) < 0x20:
-            start = flush()
-            res.append("\\u%04x" % ord(c))
+            if c in _compact_escapes:
+                res.append("\\" + _compact_escapes[c])
+            else:
+                res.append("\\u%04x" % ord(c))
+        for seq in escape_sequences:
+            seq_len = len(seq)
+            if s[i:].startswith(seq):
+                start = flush(seq_len)
+                res.append(_escaped_sequences[seq])
+                i += seq_len - 1  # fast-forward escape sequence
         i += 1
 
     flush()

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -110,7 +110,7 @@ def string(
     *,
     single_quotes: bool = False,
     multiline: bool = False,
-    escape: Union[None, bool] = None
+    escape: Union[None, bool] = None,
 ) -> String:
     """Create a string item.
 
@@ -120,7 +120,7 @@ def string(
     By default, single line strings are escaped, but multi line strings are not.
     This can be controlled by explicitly setting ``escape``.
     """
-    escape = not(multiline) if escape is None else escape
+    escape = (not multiline) if escape is None else escape
     type_ = _StringType.select(single_quotes, multiline)
     return String.from_raw(raw, type_, escape)
 

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -23,6 +23,7 @@ from .items import Item as _Item
 from .items import Key
 from .items import SingleKey
 from .items import String
+from .items import StringType as _StringType
 from .items import Table
 from .items import Time
 from .items import Trivia
@@ -104,9 +105,24 @@ def boolean(raw: str) -> Bool:
     return item(raw == "true")
 
 
-def string(raw: str) -> String:
-    """Create a string item."""
-    return item(raw)
+def string(
+    raw: str,
+    *,
+    single_quotes: bool = False,
+    multiline: bool = False,
+    escape: Union[None, bool] = None
+) -> String:
+    """Create a string item.
+
+    Boolean flags (e.g. ``single_quotes=True`` and/or ``multiline=True``)
+    can be used for personalization.
+
+    By default, single line strings are escaped, but multi line strings are not.
+    This can be controlled by explicitly setting ``escape``.
+    """
+    escape = not(multiline) if escape is None else escape
+    type_ = _StringType.select(single_quotes, multiline)
+    return String.from_raw(raw, type_, escape)
 
 
 def date(raw: str) -> Date:

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -108,20 +108,30 @@ def boolean(raw: str) -> Bool:
 def string(
     raw: str,
     *,
-    single_quotes: bool = False,
+    literal: bool = False,
     multiline: bool = False,
-    escape: Union[None, bool] = None,
+    escape: bool = True,
 ) -> String:
     """Create a string item.
 
-    Boolean flags (e.g. ``single_quotes=True`` and/or ``multiline=True``)
+    Boolean flags (e.g. ``literal=True`` and/or ``multiline=True``)
     can be used for personalization.
 
-    By default, single line strings are escaped, but multi line strings are not.
-    This can be controlled by explicitly setting ``escape``.
+    By default, common escaping rules will be applied so strings are valid
+    according to the TOML spec.
+
+    This can be controlled by explicitly setting ``escape=False``.
+    Please note that, if you disable escaping, you will have to make sure that
+    the given strings don't contain any forbidden character or sequence.
+
+    Also note that, although escaping is done even when ``literal=True``, to
+    prevent invalid TOML, TOML parsers will interpret literal and basic
+    strings in a different way.
+
+    For more information, please check the spec:
+    `https://toml.io/en/v1.0.0#string`_.
     """
-    escape = (not multiline) if escape is None else escape
-    type_ = _StringType.select(single_quotes, multiline)
+    type_ = _StringType.select(literal, multiline)
     return String.from_raw(raw, type_, escape)
 
 

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -114,22 +114,16 @@ def string(
 ) -> String:
     """Create a string item.
 
-    Boolean flags (e.g. ``literal=True`` and/or ``multiline=True``)
+    By default, this function will create *single line basic* strings, but
+    boolean flags (e.g. ``literal=True`` and/or ``multiline=True``)
     can be used for personalization.
 
-    By default, common escaping rules will be applied so strings are valid
-    according to the TOML spec.
+    For more information, please check the spec: `https://toml.io/en/v1.0.0#string`_.
 
+    Common escaping rules will be applied for basic strings.
     This can be controlled by explicitly setting ``escape=False``.
     Please note that, if you disable escaping, you will have to make sure that
     the given strings don't contain any forbidden character or sequence.
-
-    Also note that, although escaping is done even when ``literal=True``, to
-    prevent invalid TOML, TOML parsers will interpret literal and basic
-    strings in a different way.
-
-    For more information, please check the spec:
-    `https://toml.io/en/v1.0.0#string`_.
     """
     type_ = _StringType.select(literal, multiline)
     return String.from_raw(raw, type_, escape)

--- a/tomlkit/exceptions.py
+++ b/tomlkit/exceptions.py
@@ -1,3 +1,4 @@
+from typing import Collection
 from typing import Optional
 
 
@@ -213,3 +214,12 @@ class InvalidControlChar(ParseError):
         )
 
         super().__init__(line, col, message=message)
+
+
+class InvalidStringError(ValueError, TOMLKitError):
+    def __init__(self, value: str, invalid_sequences: Collection[str], delimiter: str):
+        repr_ = repr(value)[1:-1]
+        super().__init__(
+            f"Invalid string: {delimiter}{repr_}{delimiter}. "
+            f"The character sequences {invalid_sequences} are invalid."
+        )

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -124,9 +124,7 @@ def item(
 
         return a
     elif isinstance(value, str):
-        escaped = escape_string(value)
-
-        return String(StringType.SLB, decode(value), escaped, Trivia())
+        return String.from_raw(value, escape=True)
     elif isinstance(value, datetime):
         return DateTime(
             value.year,

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -166,6 +166,15 @@ class StringType(Enum):
     # Multi Line Literal
     MLL = "'''"
 
+    @classmethod
+    def select(cls, single_quotes=False, multiline=False) -> "StringType":
+        return {
+            (False, False): cls.SLB,
+            (False, True): cls.MLB,
+            (True, False): cls.SLL,
+            (True, True): cls.MLL,
+        }[(single_quotes, multiline)]
+
     @property
     @lru_cache(maxsize=None)
     def unit(self) -> str:
@@ -1511,6 +1520,12 @@ class String(str, Item):
 
     def _getstate(self, protocol=3):
         return self._t, str(self), self._original, self._trivia
+
+    @classmethod
+    def from_raw(cls, value: str, type_=StringType.SLB, escape=False) -> "String":
+        string_value = escape_string(value) if escape else value
+
+        return cls(type_, decode(value), string_value, Trivia())
 
 
 class AoT(Item, _CustomList):


### PR DESCRIPTION
Hello, it would be interesting to expose a way of controlling the string style (e.g. allowing multi line strings).

This PR is an attempt to provide such API.

I ended up going for a very verbose API (with explicit keywords) because I believe that it is easier to use, but please let me know if you prefer exposing `StringType` as part of the public API.

I think this closes #44.