### PR TITLE
Add unwrap method to recursive convert to plain old python objects

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -28,6 +28,7 @@ from tomlkit.items import Table
 from tomlkit.items import Trivia
 from tomlkit.items import Item
 from tomlkit.items import item
+from tomlkit.items import Null
 from tomlkit.parser import Parser
 from tomlkit.check import is_tomlkit
 
@@ -114,6 +115,23 @@ def test_true_unwrap():
 def test_datetime_unwrap():
     dt=datetime.utcnow()
     elementary_test(item(dt), DateTime, datetime)
+def test_string_unwrap():
+    elementary_test(item("hello"), String, str)
+def test_null_unwrap():
+    n = Null()
+    elementary_test(n, Null, type(None))
+def test_aot_unwrap():
+    d = item([{"a": "A"}, {"b": "B"}])
+    assert is_tomlkit(d)
+    unwrapped = d.unwrap()
+    assert type(unwrapped) == list
+    for de in unwrapped:
+        assert type(de) == dict
+        for k in de:
+            v = de[k]
+            assert type(k) == str
+            assert type(v) == str
+
 def test_time_unwrap():
     t=time(3, 8, 14)
     elementary_test(item(t), Time, time)

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -29,6 +29,7 @@ from tomlkit.items import Trivia
 from tomlkit.items import Item
 from tomlkit.items import item
 from tomlkit.parser import Parser
+from tomlkit.check import is_tomlkit
 
 
 @pytest.fixture()
@@ -130,6 +131,18 @@ def test_array_unwrap():
     assert_is_ppo(a_unwrapped[0], Integer, int)
     assert_is_ppo(a_unwrapped[1], Float, float)
     assert_is_ppo(a_unwrapped[2], Bool, bool)
+def test_abstract_table_unwrap():
+    table = item({"foo": "bar"})
+    super_table = item({"table": table, "baz": "borg"})
+    assert is_tomlkit(super_table["table"])
+
+    table_unwrapped = super_table.unwrap()
+    assert type(table_unwrapped) == dict
+    sub_table = table_unwrapped["table"]
+    assert type(sub_table) == dict
+    for (k, v) in zip(sub_table.keys(), sub_table):
+        assert type(k) == str
+        assert type(v) == str
 
 def test_key_comparison():
     k = Key("foo")

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -8,6 +8,9 @@ from datetime import timedelta
 
 import pytest
 
+from .util import assert_is_ppo
+from .util import elementary_test
+
 from tomlkit import api
 from tomlkit import parse
 from tomlkit.exceptions import NonExistentKey
@@ -88,15 +91,6 @@ def test_item_base_has_no_unwrap():
     else:
         raise AssertionError("`items.Item` should not implement `unwrap`")
 
-def assert_is_ppo(v_unwrapped, TomlkitType, unwrappedType):
-    assert not isinstance(v_unwrapped, TomlkitType)
-    assert isinstance(v_unwrapped, unwrappedType)
-
-def elementary_test(v, TomlkitType, unwrappedType):
-    v_unwrapped = v.unwrap()
-    assert isinstance(v, TomlkitType)
-    assert_is_ppo(v_unwrapped, TomlkitType, unwrappedType)
-
 # a check thats designed to fail to make sure the tests works
 # TODO Remove before merge (maybe?)
 def elementary_fail(v, TomlkitType, unwrappedType):
@@ -107,39 +101,39 @@ def elementary_fail(v, TomlkitType, unwrappedType):
     assert type(v) != unwrappedType
 
 def test_integer_unwrap():
-    elementary_test(item(666), Integer, int)
+    elementary_test(item(666), int)
 def test_float_unwrap():
-    elementary_test(item(2.78), Float, float)
+    elementary_test(item(2.78), float)
 def test_false_unwrap():
-    elementary_test(item(False), Bool, bool)
+    elementary_test(item(False), bool)
 def test_true_unwrap():
-    elementary_test(item(True), Bool, bool)
+    elementary_test(item(True), bool)
 def test_datetime_unwrap():
     dt=datetime.utcnow()
-    elementary_test(item(dt), DateTime, datetime)
+    elementary_test(item(dt), datetime)
 def test_string_unwrap():
-    elementary_test(item("hello"), String, str)
+    elementary_test(item("hello"), str)
 def test_null_unwrap():
     n = Null()
-    elementary_test(n, Null, type(None))
+    elementary_test(n, type(None))
 def test_aot_unwrap():
     d = item([{"a": "A"}, {"b": "B"}])
     assert is_tomlkit(d)
     unwrapped = d.unwrap()
-    assert_is_ppo(unwrapped, AoT, list)
+    assert_is_ppo(unwrapped, list)
     for du, dw in zip(unwrapped, d):
-        assert_is_ppo(du, Table, dict)
+        assert_is_ppo(du, dict)
         for ku in du:
             vu = du[ku]
-            assert_is_ppo(ku, String, str)
-            assert_is_ppo(vu, String, str)
+            assert_is_ppo(ku, str)
+            assert_is_ppo(vu, str)
 
 def test_time_unwrap():
     t=time(3, 8, 14)
-    elementary_test(item(t), Time, time)
+    elementary_test(item(t), time)
 def test_date_unwrap():
     d=date.today()
-    elementary_test(item(d), Date, date)
+    elementary_test(item(d), date)
 def test_array_unwrap():
     trivia = Trivia(indent='\t', comment_ws=' ', comment='For unit test')
     i=item(666)
@@ -147,10 +141,10 @@ def test_array_unwrap():
     b=item(False)
     a=Array([i, f, b], trivia)
     a_unwrapped=a.unwrap()
-    assert_is_ppo(a_unwrapped, Array, list)
-    assert_is_ppo(a_unwrapped[0], Integer, int)
-    assert_is_ppo(a_unwrapped[1], Float, float)
-    assert_is_ppo(a_unwrapped[2], Bool, bool)
+    assert_is_ppo(a_unwrapped, list)
+    assert_is_ppo(a_unwrapped[0], int)
+    assert_is_ppo(a_unwrapped[1], float)
+    assert_is_ppo(a_unwrapped[2], bool)
 def test_abstract_table_unwrap():
     table = item({"foo": "bar"})
     super_table = item({"table": table, "baz": "borg"})
@@ -158,12 +152,12 @@ def test_abstract_table_unwrap():
 
     table_unwrapped = super_table.unwrap()
     sub_table = table_unwrapped["table"]
-    assert_is_ppo(table_unwrapped, Table, dict)
-    assert_is_ppo(sub_table, Table, dict)
+    assert_is_ppo(table_unwrapped, dict)
+    assert_is_ppo(sub_table, dict)
     for ku in sub_table:
         vu = sub_table[ku]
-        assert_is_ppo(ku, String, str)
-        assert_is_ppo(vu, String, str)
+        assert_is_ppo(ku, str)
+        assert_is_ppo(vu, str)
 
 def test_key_comparison():
     k = Key("foo")

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -69,6 +69,24 @@ def tz_utc():
         return UTC()
 
 
+def test_item_base_has_no_unwrap():
+    trivia = Trivia(indent='\t', comment_ws=' ', comment='For unit test')
+    item = items.Item(trivia)
+    try:
+        item.unwrap()
+    except NotImplementedError:
+        pass
+    else:
+        raise AssertionError("`items.Item` should not implement `unwrap`")
+
+def test_integer_unwrap():
+    i = item(666)
+
+    i_unwrapped = i.unwrap()
+
+    assert type(i) == Integer
+    assert type(i_unwrapped) != Integer
+
 def test_key_comparison():
     k = Key("foo")
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -27,6 +27,7 @@ from tomlkit.items import StringType
 from tomlkit.items import Table
 from tomlkit.items import Trivia
 from tomlkit.items import Item
+from tomlkit.items import AoT
 from tomlkit.items import item
 from tomlkit.items import Null
 from tomlkit.parser import Parser
@@ -88,15 +89,16 @@ def test_item_base_has_no_unwrap():
         raise AssertionError("`items.Item` should not implement `unwrap`")
 
 def assert_is_ppo(v_unwrapped, TomlkitType, unwrappedType):
-    assert type(v_unwrapped) != TomlkitType
-    assert type(v_unwrapped) == unwrappedType
+    assert not isinstance(v_unwrapped, TomlkitType)
+    assert isinstance(v_unwrapped, unwrappedType)
 
 def elementary_test(v, TomlkitType, unwrappedType):
     v_unwrapped = v.unwrap()
-    assert type(v) == TomlkitType
-    assert type(v) != unwrappedType
+    assert isinstance(v, TomlkitType)
     assert_is_ppo(v_unwrapped, TomlkitType, unwrappedType)
 
+# a check thats designed to fail to make sure the tests works
+# TODO Remove before merge (maybe?)
 def elementary_fail(v, TomlkitType, unwrappedType):
     v_unwrapped = v.unwrap()
     assert type(v) == TomlkitType
@@ -124,13 +126,13 @@ def test_aot_unwrap():
     d = item([{"a": "A"}, {"b": "B"}])
     assert is_tomlkit(d)
     unwrapped = d.unwrap()
-    assert type(unwrapped) == list
-    for de in unwrapped:
-        assert type(de) == dict
-        for k in de:
-            v = de[k]
-            assert type(k) == str
-            assert type(v) == str
+    assert_is_ppo(unwrapped, AoT, list)
+    for du, dw in zip(unwrapped, d):
+        assert_is_ppo(du, Table, dict)
+        for ku in du:
+            vu = du[ku]
+            assert_is_ppo(ku, String, str)
+            assert_is_ppo(vu, String, str)
 
 def test_time_unwrap():
     t=time(3, 8, 14)
@@ -145,7 +147,7 @@ def test_array_unwrap():
     b=item(False)
     a=Array([i, f, b], trivia)
     a_unwrapped=a.unwrap()
-    assert type(a_unwrapped) == list
+    assert_is_ppo(a_unwrapped, Array, list)
     assert_is_ppo(a_unwrapped[0], Integer, int)
     assert_is_ppo(a_unwrapped[1], Float, float)
     assert_is_ppo(a_unwrapped[2], Bool, bool)
@@ -155,12 +157,13 @@ def test_abstract_table_unwrap():
     assert is_tomlkit(super_table["table"])
 
     table_unwrapped = super_table.unwrap()
-    assert type(table_unwrapped) == dict
     sub_table = table_unwrapped["table"]
-    assert type(sub_table) == dict
-    for (k, v) in zip(sub_table.keys(), sub_table):
-        assert type(k) == str
-        assert type(v) == str
+    assert_is_ppo(table_unwrapped, Table, dict)
+    assert_is_ppo(sub_table, Table, dict)
+    for ku in sub_table:
+        vu = sub_table[ku]
+        assert_is_ppo(ku, String, str)
+        assert_is_ppo(vu, String, str)
 
 def test_key_comparison():
     k = Key("foo")

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -91,15 +91,6 @@ def test_item_base_has_no_unwrap():
     else:
         raise AssertionError("`items.Item` should not implement `unwrap`")
 
-# a check thats designed to fail to make sure the tests works
-# TODO Remove before merge (maybe?)
-def elementary_fail(v, TomlkitType, unwrappedType):
-    v_unwrapped = v.unwrap()
-    assert type(v) == TomlkitType
-    assert type(v_unwrapped) == TomlkitType
-    assert type(v_unwrapped) == unwrappedType
-    assert type(v) != unwrappedType
-
 def test_integer_unwrap():
     elementary_test(item(666), int)
 def test_float_unwrap():

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -8,33 +8,33 @@ from datetime import timedelta
 
 import pytest
 
-from .util import assert_is_ppo
-from .util import elementary_test
-
 from tomlkit import api
 from tomlkit import parse
+from tomlkit.check import is_tomlkit
 from tomlkit.exceptions import NonExistentKey
+from tomlkit.items import AoT
+from tomlkit.items import Array
 from tomlkit.items import Bool
 from tomlkit.items import Comment
+from tomlkit.items import Date
+from tomlkit.items import DateTime
+from tomlkit.items import Float
 from tomlkit.items import InlineTable
 from tomlkit.items import Integer
-from tomlkit.items import Float
-from tomlkit.items import DateTime
-from tomlkit.items import Date
-from tomlkit.items import Time
-from tomlkit.items import Array
+from tomlkit.items import Item
 from tomlkit.items import KeyType
+from tomlkit.items import Null
 from tomlkit.items import SingleKey as Key
 from tomlkit.items import String
 from tomlkit.items import StringType
 from tomlkit.items import Table
+from tomlkit.items import Time
 from tomlkit.items import Trivia
-from tomlkit.items import Item
-from tomlkit.items import AoT
 from tomlkit.items import item
-from tomlkit.items import Null
 from tomlkit.parser import Parser
-from tomlkit.check import is_tomlkit
+
+from .util import assert_is_ppo
+from .util import elementary_test
 
 
 @pytest.fixture()
@@ -82,7 +82,7 @@ def tz_utc():
 
 
 def test_item_base_has_no_unwrap():
-    trivia = Trivia(indent='\t', comment_ws=' ', comment='For unit test')
+    trivia = Trivia(indent="\t", comment_ws=" ", comment="For unit test")
     item = Item(trivia)
     try:
         item.unwrap()
@@ -91,22 +91,37 @@ def test_item_base_has_no_unwrap():
     else:
         raise AssertionError("`items.Item` should not implement `unwrap`")
 
+
 def test_integer_unwrap():
     elementary_test(item(666), int)
+
+
 def test_float_unwrap():
     elementary_test(item(2.78), float)
+
+
 def test_false_unwrap():
     elementary_test(item(False), bool)
+
+
 def test_true_unwrap():
     elementary_test(item(True), bool)
+
+
 def test_datetime_unwrap():
-    dt=datetime.utcnow()
+    dt = datetime.utcnow()
     elementary_test(item(dt), datetime)
+
+
 def test_string_unwrap():
     elementary_test(item("hello"), str)
+
+
 def test_null_unwrap():
     n = Null()
     elementary_test(n, type(None))
+
+
 def test_aot_unwrap():
     d = item([{"a": "A"}, {"b": "B"}])
     assert is_tomlkit(d)
@@ -119,23 +134,30 @@ def test_aot_unwrap():
             assert_is_ppo(ku, str)
             assert_is_ppo(vu, str)
 
+
 def test_time_unwrap():
-    t=time(3, 8, 14)
+    t = time(3, 8, 14)
     elementary_test(item(t), time)
+
+
 def test_date_unwrap():
-    d=date.today()
+    d = date.today()
     elementary_test(item(d), date)
+
+
 def test_array_unwrap():
-    trivia = Trivia(indent='\t', comment_ws=' ', comment='For unit test')
-    i=item(666)
-    f=item(2.78)
-    b=item(False)
-    a=Array([i, f, b], trivia)
-    a_unwrapped=a.unwrap()
+    trivia = Trivia(indent="\t", comment_ws=" ", comment="For unit test")
+    i = item(666)
+    f = item(2.78)
+    b = item(False)
+    a = Array([i, f, b], trivia)
+    a_unwrapped = a.unwrap()
     assert_is_ppo(a_unwrapped, list)
     assert_is_ppo(a_unwrapped[0], int)
     assert_is_ppo(a_unwrapped[1], float)
     assert_is_ppo(a_unwrapped[2], bool)
+
+
 def test_abstract_table_unwrap():
     table = item({"foo": "bar"})
     super_table = item({"table": table, "baz": "borg"})
@@ -149,6 +171,7 @@ def test_abstract_table_unwrap():
         vu = sub_table[ku]
         assert_is_ppo(ku, str)
         assert_is_ppo(vu, str)
+
 
 def test_key_comparison():
     k = Key("foo")

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -9,15 +9,15 @@ import pytest
 
 import tomlkit
 
-from .util import assert_is_ppo
-from .util import elementary_test
-
 from tomlkit import parse
 from tomlkit import ws
 from tomlkit._utils import _utc
 from tomlkit.api import document
 from tomlkit.exceptions import NonExistentKey
 from tomlkit.toml_document import TOMLDocument
+
+from .util import assert_is_ppo
+from .util import elementary_test
 
 
 def test_document_is_a_dict(example):
@@ -157,13 +157,14 @@ name = "bar"
 
     assert "tool" in d
 
+
 def test_toml_document_unwrap():
     content = """[tool.poetry]
 name = "foo"
 """
 
     doc = parse(content)
-    unwrapped=doc.unwrap()
+    unwrapped = doc.unwrap()
     assert_is_ppo(unwrapped, dict)
     assert_is_ppo(list(unwrapped.keys())[0], str)
     assert_is_ppo(unwrapped["tool"], dict)

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -153,6 +153,19 @@ name = "bar"
 
     assert "tool" in d
 
+def test_toml_document_unwrap():
+    content = """[tool.poetry]
+name = "foo"
+"""
+
+    doc = parse(content)
+    unwrapped=doc.unwrap()
+    assert type(unwrapped) == dict
+    assert type(list(unwrapped.keys())[0]) == str
+    assert type(unwrapped["tool"]) == dict
+    assert type(list(unwrapped["tool"].keys())[0]) == str
+    assert type(unwrapped["tool"]["poetry"]["name"]) == str
+
 
 def test_toml_document_with_dotted_keys(example):
     content = example("0.5.0")

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -9,11 +9,15 @@ import pytest
 
 import tomlkit
 
+from .util import assert_is_ppo
+from .util import elementary_test
+
 from tomlkit import parse
 from tomlkit import ws
 from tomlkit._utils import _utc
 from tomlkit.api import document
 from tomlkit.exceptions import NonExistentKey
+from tomlkit.toml_document import TOMLDocument
 
 
 def test_document_is_a_dict(example):
@@ -160,11 +164,11 @@ name = "foo"
 
     doc = parse(content)
     unwrapped=doc.unwrap()
-    assert type(unwrapped) == dict
-    assert type(list(unwrapped.keys())[0]) == str
-    assert type(unwrapped["tool"]) == dict
-    assert type(list(unwrapped["tool"].keys())[0]) == str
-    assert type(unwrapped["tool"]["poetry"]["name"]) == str
+    assert_is_ppo(unwrapped, dict)
+    assert_is_ppo(list(unwrapped.keys())[0], str)
+    assert_is_ppo(unwrapped["tool"], dict)
+    assert_is_ppo(list(unwrapped["tool"].keys())[0], str)
+    assert_is_ppo(unwrapped["tool"]["poetry"]["name"], str)
 
 
 def test_toml_document_with_dotted_keys(example):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,53 @@
+from tomlkit.items import Bool
+from tomlkit.items import Comment
+from tomlkit.items import InlineTable
+from tomlkit.items import Integer
+from tomlkit.items import Float
+from tomlkit.items import DateTime
+from tomlkit.items import Date
+from tomlkit.items import Time
+from tomlkit.items import Array
+from tomlkit.items import KeyType
+from tomlkit.items import SingleKey as Key
+from tomlkit.items import String
+from tomlkit.items import StringType
+from tomlkit.items import Table
+from tomlkit.items import Trivia
+from tomlkit.items import Item
+from tomlkit.items import AoT
+from tomlkit.items import Null
+from tomlkit.toml_document import TOMLDocument
+
+TOMLKIT_TYPES = [
+    Bool,
+    Comment,
+    InlineTable,
+    Integer,
+    Float,
+    DateTime,
+    Date,
+    Time,
+    Array,
+    KeyType,
+    Key,
+    String,
+    StringType,
+    Table,
+    Trivia,
+    Item,
+    AoT,
+    Null,
+    TOMLDocument
+]
+
+def assert_not_tomlkit_type(v):
+    for i, T in enumerate(TOMLKIT_TYPES):
+        assert not isinstance(v, T)
+
+def assert_is_ppo(v_unwrapped, unwrappedType):
+    assert_not_tomlkit_type(v_unwrapped)
+    assert isinstance(v_unwrapped, unwrappedType)
+
+def elementary_test(v, unwrappedType):
+    v_unwrapped = v.unwrap()
+    assert_is_ppo(v_unwrapped, unwrappedType)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,22 +1,23 @@
+from tomlkit.items import AoT
+from tomlkit.items import Array
 from tomlkit.items import Bool
 from tomlkit.items import Comment
+from tomlkit.items import Date
+from tomlkit.items import DateTime
+from tomlkit.items import Float
 from tomlkit.items import InlineTable
 from tomlkit.items import Integer
-from tomlkit.items import Float
-from tomlkit.items import DateTime
-from tomlkit.items import Date
-from tomlkit.items import Time
-from tomlkit.items import Array
+from tomlkit.items import Item
 from tomlkit.items import KeyType
+from tomlkit.items import Null
 from tomlkit.items import SingleKey as Key
 from tomlkit.items import String
 from tomlkit.items import StringType
 from tomlkit.items import Table
+from tomlkit.items import Time
 from tomlkit.items import Trivia
-from tomlkit.items import Item
-from tomlkit.items import AoT
-from tomlkit.items import Null
 from tomlkit.toml_document import TOMLDocument
+
 
 TOMLKIT_TYPES = [
     Bool,
@@ -37,16 +38,19 @@ TOMLKIT_TYPES = [
     Item,
     AoT,
     Null,
-    TOMLDocument
+    TOMLDocument,
 ]
+
 
 def assert_not_tomlkit_type(v):
     for i, T in enumerate(TOMLKIT_TYPES):
         assert not isinstance(v, T)
 
+
 def assert_is_ppo(v_unwrapped, unwrappedType):
     assert_not_tomlkit_type(v_unwrapped)
     assert isinstance(v_unwrapped, unwrappedType)
+
 
 def elementary_test(v, unwrappedType):
     v_unwrapped = v.unwrap()

--- a/tomlkit/check.py
+++ b/tomlkit/check.py
@@ -1,0 +1,21 @@
+def is_ppo(v):
+    from datetime import date
+    from datetime import datetime
+    from datetime import time
+    from datetime import timedelta
+    PPO_TYPES = [int, bool, float, date, time, datetime, list, tuple, dict, str]
+    if type(v) in PPO_TYPES:
+        return True
+    return False
+
+def is_tomlkit(v):
+    from .items import Item as _Item
+    from .container import Container
+    from .container import OutOfOrderTableProxy
+    if isinstance(v, _Item):
+        return True
+    if isinstance(v, Container):
+        return True
+    if isinstance(v, OutOfOrderTableProxy):
+        return True
+    return False

--- a/tomlkit/check.py
+++ b/tomlkit/check.py
@@ -1,13 +1,3 @@
-def is_ppo(v):
-    from datetime import date
-    from datetime import datetime
-    from datetime import time
-    from datetime import timedelta
-    PPO_TYPES = [int, bool, float, date, time, datetime, list, tuple, dict, str]
-    if type(v) in PPO_TYPES:
-        return True
-    return False
-
 def is_tomlkit(v):
     from .items import Item as _Item
     from .container import Container

--- a/tomlkit/check.py
+++ b/tomlkit/check.py
@@ -1,7 +1,8 @@
 def is_tomlkit(v):
-    from .items import Item as _Item
     from .container import Container
     from .container import OutOfOrderTableProxy
+    from .items import Item as _Item
+
     if isinstance(v, _Item):
         return True
     if isinstance(v, Container):

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -48,7 +48,7 @@ class Container(_CustomDict):
 
     def unwrap(self, recursive: bool = True) -> str:
         unwrapped = {}
-        for k, v in self._body:
+        for k, v in self.items():
             if k is None:
                 continue
 

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -46,22 +46,25 @@ class Container(_CustomDict):
     def body(self) -> List[Tuple[Optional[Key], Item]]:
         return self._body
 
+    def _unwrap_inner(self, k, v, d):
+        if k is None:
+            return
+
+        k = k.key
+        v = v.value
+
+        if isinstance(v, Container):
+            v = v.value
+
+        if k in d:
+            merge_dicts(d[k], v)
+        else:
+            d[k] = v
+
     def unwrap(self) -> str:
         unwrapped = {}
         for k, v in self.items():
-            if k is None:
-                continue
-
-            k = k.key
-            v = v.value
-
-            if isinstance(v, Container):
-                v = v.unwrap()
-
-            if k in unwrapped:
-                merge_dicts(unwrapped[k], v)
-            else:
-                unwrapped[k] = v.unwrap()
+            self._unwrap_inner(k, v, unwrapped)
 
         return unwrapped
 
@@ -69,19 +72,7 @@ class Container(_CustomDict):
     def value(self) -> Dict[Any, Any]:
         d = {}
         for k, v in self._body:
-            if k is None:
-                continue
-
-            k = k.key
-            v = v.value
-
-            if isinstance(v, Container):
-                v = v.value
-
-            if k in d:
-                merge_dicts(d[k], v)
-            else:
-                d[k] = v
+            self._unwrap_inner(k, v, d)
 
         return d
 

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -10,6 +10,7 @@ from typing import Union
 
 from ._compat import decode
 from ._utils import merge_dicts
+from .check import is_tomlkit
 from .exceptions import KeyAlreadyPresent
 from .exceptions import NonExistentKey
 from .exceptions import TOMLKitError
@@ -24,8 +25,6 @@ from .items import Trivia
 from .items import Whitespace
 from .items import _CustomDict
 from .items import item as _item
-
-from .check import is_tomlkit
 
 
 _NOT_SET = object()

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -46,6 +46,25 @@ class Container(_CustomDict):
     def body(self) -> List[Tuple[Optional[Key], Item]]:
         return self._body
 
+    def unwrap(self, recursive: bool = True) -> str:
+        unwrapped = {}
+        for k, v in self._body:
+            if k is None:
+                continue
+
+            k = k.key
+            v = v.value
+
+            if isinstance(v, Container):
+                v = v.unwrap(recursive=recursive)
+
+            if k in unwrapped:
+                merge_dicts(unwrapped[k], v)
+            else:
+                unwrapped[k] = v.unwrap(recursive=recursive)
+
+        return unwrapped
+
     @property
     def value(self) -> Dict[Any, Any]:
         d = {}
@@ -795,6 +814,9 @@ class OutOfOrderTableProxy(_CustomDict):
                     self._tables_map[k] = table_idx
                     if k is not None:
                         dict.__setitem__(self, k.key, v)
+
+    def unwrap(self, recursive: bool = True) -> str:
+        return self._internal_container.unwrap(recursive=recursive)
 
     @property
     def value(self):

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -54,10 +54,10 @@ class Container(_CustomDict):
             if k is None:
                 continue
 
-            if not type(k) == str:
+            if not isinstance(k, str):
                 k = k.key
 
-            if not type(v) == str:
+            if not isinstance(v, str):
                 v = v.unwrap()
 
             if k in unwrapped:

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -57,8 +57,10 @@ class Container(_CustomDict):
             if not isinstance(k, str):
                 k = k.key
 
-            if not isinstance(v, str):
+            try:
                 v = v.unwrap()
+            except AttributeError:
+                pass
 
             if k in unwrapped:
                 merge_dicts(unwrapped[k], v)

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -57,10 +57,8 @@ class Container(_CustomDict):
             if not isinstance(k, str):
                 k = k.key
 
-            try:
+            if isinstance(v, Item):
                 v = v.unwrap()
-            except AttributeError:
-                pass
 
             if k in unwrapped:
                 merge_dicts(unwrapped[k], v)

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -46,7 +46,7 @@ class Container(_CustomDict):
     def body(self) -> List[Tuple[Optional[Key], Item]]:
         return self._body
 
-    def unwrap(self, recursive: bool = True) -> str:
+    def unwrap(self) -> str:
         unwrapped = {}
         for k, v in self.items():
             if k is None:
@@ -56,12 +56,12 @@ class Container(_CustomDict):
             v = v.value
 
             if isinstance(v, Container):
-                v = v.unwrap(recursive=recursive)
+                v = v.unwrap()
 
             if k in unwrapped:
                 merge_dicts(unwrapped[k], v)
             else:
-                unwrapped[k] = v.unwrap(recursive=recursive)
+                unwrapped[k] = v.unwrap()
 
         return unwrapped
 
@@ -815,8 +815,8 @@ class OutOfOrderTableProxy(_CustomDict):
                     if k is not None:
                         dict.__setitem__(self, k.key, v)
 
-    def unwrap(self, recursive: bool = True) -> str:
-        return self._internal_container.unwrap(recursive=recursive)
+    def unwrap(self) -> str:
+        return self._internal_container.unwrap()
 
     @property
     def value(self):

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -492,7 +492,7 @@ class Item:
         """The TOML representation"""
         raise NotImplementedError()
 
-    def as_ppo(self):
+    def unwrap(self, recursive: bool = True):
         """Returns as pure python object (ppo)"""
         raise NotImplementedError()
 
@@ -616,7 +616,7 @@ class Integer(int, Item):
         if re.match(r"^[+\-]\d+$", raw):
             self._sign = True
 
-    def as_ppo(self) -> int:
+    def unwrap(self, recursive: bool = True) -> int:
         return int(self)
 
     @property
@@ -687,7 +687,7 @@ class Float(float, Item):
         if re.match(r"^[+\-].+$", raw):
             self._sign = True
 
-    def as_ppo(self) -> float:
+    def unwrap(self, recursive: bool = True) -> float:
         return float(self)
 
     @property
@@ -751,7 +751,7 @@ class Bool(Item):
 
         self._value = bool(t)
 
-    def as_ppo(self) -> bool:
+    def unwrap(self, recursive: bool = True) -> bool:
         return bool(self)
 
     @property
@@ -836,7 +836,7 @@ class DateTime(Item, datetime):
 
         self._raw = raw or self.isoformat()
 
-    def as_ppo(self) -> datetime:
+    def unwrap(self, recursive: bool = True) -> datetime:
         (year, month, day, hour, minute, second, microsecond, tzinfo, _, _) = self._getstate()
         return datetime(year, month, day, hour, minute, second, microsecond, tzinfo)
 
@@ -943,7 +943,7 @@ class Date(Item, date):
 
         self._raw = raw
 
-    def as_ppo(self) -> date:
+    def unwrap(self, recursive: bool = True) -> date:
         (year, month, day, _, _) = self._getstate()
         return date(year, month, day)
 
@@ -1019,7 +1019,7 @@ class Time(Item, time):
 
         self._raw = raw
 
-    def as_ppo(self) -> datetime:
+    def unwrap(self, recursive: bool = True) -> datetime:
         (hour, minute, second, microsecond, tzinfo, _, _) = self._getstate()
         return time(hour, minute, second, microsecond, tzinfo)
 
@@ -1322,7 +1322,7 @@ class AbstractTable(Item, _CustomDict):
             if k is not None:
                 dict.__setitem__(self, k.key, v)
 
-    def as_ppo(self):
+    def unwrap(self, recursive: bool = True):
         pass
 
     @property
@@ -1647,7 +1647,7 @@ class String(str, Item):
         self._t = t
         self._original = original
 
-    def as_ppo(self) -> str:
+    def unwrap(self, recursive: bool = True) -> str:
         return self.as_string()
 
     @property

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1731,7 +1731,7 @@ class AoT(Item, _CustomList):
     def unwrap(self) -> str:
         unwrapped = []
         for t in self._body:
-            if is_tomlkit(t):
+            if isinstance(t, Item):
                 unwrapped.append(t.unwrap())
             else:
                 unwrapped.append(t)

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -492,6 +492,10 @@ class Item:
         """The TOML representation"""
         raise NotImplementedError()
 
+    def as_ppo(self):
+        """Returns as pure python object (ppo)"""
+        raise NotImplementedError()
+
     # Helpers
 
     def comment(self, comment: str) -> "Item":
@@ -533,6 +537,8 @@ class Item:
 
     def __reduce_ex__(self, protocol):
         return self.__class__, self._getstate(protocol)
+
+    def 
 
 
 class Whitespace(Item):
@@ -610,6 +616,9 @@ class Integer(int, Item):
         if re.match(r"^[+\-]\d+$", raw):
             self._sign = True
 
+    def as_ppo(self) -> int:
+        return int(self)
+
     @property
     def discriminant(self) -> int:
         return 2
@@ -678,6 +687,9 @@ class Float(float, Item):
         if re.match(r"^[+\-].+$", raw):
             self._sign = True
 
+    def as_ppo(self) -> float:
+        return float(self)
+
     @property
     def discriminant(self) -> int:
         return 3
@@ -738,6 +750,9 @@ class Bool(Item):
         super().__init__(trivia)
 
         self._value = bool(t)
+
+    def as_ppo(self) -> bool:
+        return bool(self)
 
     @property
     def discriminant(self) -> int:
@@ -820,6 +835,10 @@ class DateTime(Item, datetime):
         super().__init__(trivia or Trivia())
 
         self._raw = raw or self.isoformat()
+
+    def as_ppo(self) -> datetime:
+        (year, month, day, hour, minute, second, microsecond, tzinfo, _, _) = self._getstate()
+        return datetime(year, month, day, hour, minute, second, microsecond, tzinfo)
 
     @property
     def discriminant(self) -> int:
@@ -924,6 +943,10 @@ class Date(Item, date):
 
         self._raw = raw
 
+    def as_ppo(self) -> date:
+        (year, month, day, _, _) = self._getstate()
+        return date(year, month, day)
+
     @property
     def discriminant(self) -> int:
         return 6
@@ -995,6 +1018,10 @@ class Time(Item, time):
         super().__init__(trivia)
 
         self._raw = raw
+
+    def as_ppo(self) -> datetime:
+        (hour, minute, second, microsecond, tzinfo, _, _) = self._getstate()
+        return time(hour, minute, second, microsecond, tzinfo)
 
     @property
     def discriminant(self) -> int:
@@ -1294,6 +1321,9 @@ class AbstractTable(Item, _CustomDict):
         for k, v in self._value.body:
             if k is not None:
                 dict.__setitem__(self, k.key, v)
+
+    def as_ppo(self):
+        pass
 
     @property
     def value(self) -> "container.Container":
@@ -1616,6 +1646,9 @@ class String(str, Item):
 
         self._t = t
         self._original = original
+
+    def as_ppo(self) -> str:
+        return self.as_string()
 
     @property
     def discriminant(self) -> int:

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1333,10 +1333,15 @@ class AbstractTable(Item, _CustomDict):
     def unwrap(self):
         unwrapped = {}
         for k in self:
-            if is_tomlkit(v):
-                unwrapped[k] = self[k].unwrap()
+            if is_tomlkit(k):
+                nk = k.unwrap()
             else:
-                unwrapped[k] = self[k]
+                nk = k
+            if is_tomlkit(self[k]):
+                nv = self[k].unwrap()
+            else:
+                nv = self[k]
+            unwrapped[nk] = nv
 
         return unwrapped
 

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -538,8 +538,6 @@ class Item:
     def __reduce_ex__(self, protocol):
         return self.__class__, self._getstate(protocol)
 
-    def 
-
 
 class Whitespace(Item):
     """

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1731,7 +1731,7 @@ class AoT(Item, _CustomList):
     def unwrap(self) -> str:
         unwrapped = []
         for t in self._body:
-            if is_tomlkit(v):
+            if is_tomlkit(t):
                 unwrapped.append(t.unwrap())
             else:
                 unwrapped.append(t)

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1078,6 +1078,15 @@ class Array(Item, _CustomList):
         self._multiline = multiline
         self._reindex()
 
+    def unwrap(self, recursive: bool = True) -> str:
+        unwrapped = []
+        for v in self:
+            if recursive:
+                unwrapped.append(v.unwrap(recursive=recursive))
+            else:
+                unwrapped.append(v)
+        return unwrapped
+
     @property
     def discriminant(self) -> int:
         return 8
@@ -1323,7 +1332,14 @@ class AbstractTable(Item, _CustomDict):
                 dict.__setitem__(self, k.key, v)
 
     def unwrap(self, recursive: bool = True):
-        pass
+        unwrapped = {}
+        for k in self:
+            if recursive:
+                unwrapped[k] = self[k].unwrap(recursive=recursive)
+            else:
+                unwrapped[k] = self[k]
+
+        return unwrapped
 
     @property
     def value(self) -> "container.Container":
@@ -1708,6 +1724,15 @@ class AoT(Item, _CustomList):
         for table in body:
             self.append(table)
 
+    def unwrap(self, recursive: bool = True) -> str:
+        unwrapped = []
+        for t in self._body:
+            if recursive:
+                unwrapped.append(t.unwrap(recursive=recursive))
+            else:
+                unwrapped.append(t)
+        return unwrapped
+
     @property
     def body(self) -> List[Table]:
         return self._body
@@ -1798,6 +1823,9 @@ class Null(Item):
 
     def __init__(self) -> None:
         pass
+
+    def unwrap(self, recursive: bool = True) -> str:
+        return None
 
     @property
     def discriminant(self) -> int:

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -27,9 +27,9 @@ from ._compat import PY38
 from ._compat import decode
 from ._utils import CONTROL_CHARS
 from ._utils import escape_string
+from .check import is_tomlkit
 from .exceptions import InvalidStringError
 from .toml_char import TOMLChar
-from .check import is_tomlkit
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -836,7 +836,18 @@ class DateTime(Item, datetime):
         self._raw = raw or self.isoformat()
 
     def unwrap(self) -> datetime:
-        (year, month, day, hour, minute, second, microsecond, tzinfo, _, _) = self._getstate()
+        (
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            microsecond,
+            tzinfo,
+            _,
+            _,
+        ) = self._getstate()
         return datetime(year, month, day, hour, minute, second, microsecond, tzinfo)
 
     @property


### PR DESCRIPTION
Adds methods to convert TOMLKit objects to plain python methods

Fixes #43 