### PR TITLE
Keep consistent line endings

### DIFF
--- a/tomlkit/toml_file.py
+++ b/tomlkit/toml_file.py
@@ -1,3 +1,6 @@
+import os
+import re
+
 from .api import loads
 from .toml_document import TOMLDocument
 
@@ -11,13 +14,35 @@ class TOMLFile:
 
     def __init__(self, path: str) -> None:
         self._path = path
+        self._linesep = os.linesep
 
     def read(self) -> TOMLDocument:
         """Read the file content as a :class:`tomlkit.toml_document.TOMLDocument`."""
         with open(self._path, encoding="utf-8", newline="") as f:
-            return loads(f.read())
+            content = f.read()
+
+            # check if consistent line endings
+            num_newline = content.count("\n")
+            if num_newline > 0:
+                num_win_eol = content.count("\r\n")
+                if num_win_eol == num_newline:
+                    self._linesep = "\r\n"
+                elif num_win_eol == 0:
+                    self._linesep = "\n"
+                else:
+                    self._linesep = "mixed"
+
+            return loads(content)
 
     def write(self, data: TOMLDocument) -> None:
         """Write the TOMLDocument to the file."""
+        content = data.as_string()
+
+        # apply linesep
+        if self._linesep == "\n":
+            content = content.replace("\r\n", "\n")
+        elif self._linesep == "\r\n":
+            content = re.sub(r"(?<!\r)\n", "\r\n", content)
+
         with open(self._path, "w", encoding="utf-8", newline="") as f:
-            f.write(data.as_string())
+            f.write(content)


### PR DESCRIPTION
Resolves: #200

With this change, when reading a toml file with consistent line endings, changing the content and writing the content into a file, the result is a file with the same consistent line endings as the input file.

Further, default line endings for Windows when creating a new toml file will be Windows line endings (`"\r\n"`) again.

This change is not perfect, because it only ensures that the written file has consistent line endings. Dumping the changed `TomlDocument` as string still has inconsistent line endings. However, keeping consistent line endings for `TomlDocument` seems to require way more effort since hard coded `"\n"` is used in many places.