### PR TITLE
fix: remove empty tables from out-of-order table proxy

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -64,7 +64,7 @@ TOML Kit provides an intuitive API to modify TOML documents::
     """
 
     # Remove the newly added table
-    >>> doc.remove("table2")
+    >>> doc.pop("table2")
     # del doc["table2] is also possible
 
 Writing

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -14,10 +14,8 @@ from tomlkit import ws
 from tomlkit._utils import _utc
 from tomlkit.api import document
 from tomlkit.exceptions import NonExistentKey
-from tomlkit.toml_document import TOMLDocument
 
 from .util import assert_is_ppo
-from .util import elementary_test
 
 
 def test_document_is_a_dict(example):
@@ -652,6 +650,31 @@ a = "b"
 """
 
     assert expected == doc.as_string()
+
+
+def test_remove_from_out_of_order_table():
+    content = """[a]
+x = 1
+
+[c]
+z = 3
+
+[a.b]
+y = 2
+"""
+    document = parse(content)
+    del document["a"]["b"]
+    assert (
+        document.as_string()
+        == """[a]
+x = 1
+
+[c]
+z = 3
+
+"""
+    )
+    assert json.dumps(document) == '{"a": {"x": 1}, "c": {"z": 3}}'
 
 
 def test_updating_nested_value_keeps_correct_indent():


### PR DESCRIPTION
- Fix #204 remove empty tables from out-of-order table proxy
- Fix #205 Forbid accessing unsupported methods on outf-of-order table