### PR TITLE
Absolute URL for documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Part of the implementation has been adapted, improved and fixed from [Molten](ht
 
 ## Usage
 
-See the [documentation](docs/quickstart.rst) for more information.
+See the [documentation](https://github.com/sdispater/tomlkit/blob/master/docs/quickstart.rst) for more information.
 
-## Installation
+## Installationsdispater/tomlkit/fork
 
 If you are using [Poetry](https://poetry.eustace.io),
 add `tomlkit` to your `pyproject.toml` file by using:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Part of the implementation has been adapted, improved and fixed from [Molten](ht
 
 See the [documentation](https://github.com/sdispater/tomlkit/blob/master/docs/quickstart.rst) for more information.
 
-## Installationsdispater/tomlkit/fork
+## Installation
 
 If you are using [Poetry](https://poetry.eustace.io),
 add `tomlkit` to your `pyproject.toml` file by using:


### PR DESCRIPTION
The link does not work in [PyPI page](https://pypi.org/project/tomlkit/).