### PR TITLE
fix: don't add header when removing items from a supertable

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -983,3 +983,21 @@ def test_add_newline_before_super_table():
     [d.e]
     """
     assert doc.as_string() == dedent(expected)
+
+
+def test_remove_item_from_super_table():
+    content = """\
+    [hello.one]
+    a = 1
+
+    [hello.two]
+    b = 1
+    """
+    doc = parse(dedent(content))
+    del doc["hello"]["two"]
+    expected = """\
+    [hello.one]
+    a = 1
+
+    """
+    assert doc.as_string() == dedent(expected)

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -525,7 +525,8 @@ class Container(_CustomDict):
 
         if not table.is_super_table() or (
             any(
-                not isinstance(v, (Table, AoT, Whitespace)) for _, v in table.value.body
+                not isinstance(v, (Table, AoT, Whitespace, Null))
+                for _, v in table.value.body
             )
             and not key.is_dotted()
         ):


### PR DESCRIPTION
Fix #217