### PR TITLE
bugfix: items.Array __init__ didn't ignore Null that _group_values added.

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,5 +1,6 @@
 import math
 import pickle
+import copy
 
 from datetime import date
 from datetime import datetime
@@ -860,3 +861,17 @@ def test_table_copy():
     table["foo"] = "baz"
     assert table_copy["foo"] == "bar"
     assert table_copy.as_string() == 'foo = "bar"\n'
+
+
+def test_copy_copy():
+    result = parse("""
+    [tool.poetry]
+    classifiers = [
+    # comment
+        "a",
+        "b",
+    ]
+    """)
+    classifiers = result["tool"]["poetry"]["classifiers"]
+    new = copy.copy(classifiers)
+    assert new == classifiers

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -656,7 +656,6 @@ class Integer(int, Item):
         return self._raw
 
     def __add__(self, other):
-
         return self._new(int(self._raw) + other)
 
     def __radd__(self, other):
@@ -1139,7 +1138,8 @@ class Array(Item, _CustomList):
     ) -> None:
         super().__init__(trivia)
         list.__init__(
-            self, [v.value for v in value if not isinstance(v, (Whitespace, Comment))]
+            self,
+            [v.value for v in value if not isinstance(v, (Whitespace, Comment, Null))],
         )
         self._index_map: Dict[int, int] = {}
         self._value = self._group_values(value)


### PR DESCRIPTION
The issue is, #218 added a `_group_values` cloud add `Null` into the Array values, but the `Array`'s `list.__init__` didn't ignore this value.

Poetry will `copy.copy` an `Array` item (for e.g. here: https://github.com/python-poetry/poetry-core/blob/main/src/poetry/core/packages/package.py#L290 ), then there will be an extra `Null` object in the values, so that an Array like this:

```
[tool.poetry]
classifiers = [
# comment
    "a",
    "b",
]
```
originally is `["a", "b"]`, after being `copy.copy`ed, will become `[None, "a", "b"]` due to the `Null`. (Please see the testcase I added)

Then it will cause poetry to fail because there is an extra "None" in classifiers. ( https://github.com/laixintao/iredis/runs/7749027851?check_suite_focus=true )

related: https://github.com/sdispater/tomlkit/pull/218