### PR TITLE
fix: type annotation of unwrap() and datetime parsing

### DIFF
--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -46,7 +46,7 @@ class Container(_CustomDict):
     def body(self) -> List[Tuple[Optional[Key], Item]]:
         return self._body
 
-    def unwrap(self) -> str:
+    def unwrap(self) -> Dict[str, Any]:
         unwrapped = {}
         for k, v in self.items():
             if k is None:
@@ -66,7 +66,7 @@ class Container(_CustomDict):
         return unwrapped
 
     @property
-    def value(self) -> Dict[Any, Any]:
+    def value(self) -> Dict[str, Any]:
         d = {}
         for k, v in self._body:
             if k is None:

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -503,7 +503,11 @@ class Item:
         """The TOML representation"""
         raise NotImplementedError()
 
-    def unwrap(self):
+    @property
+    def value(self) -> Any:
+        return self
+
+    def unwrap(self) -> Any:
         """Returns as pure python object (ppo)"""
         raise NotImplementedError()
 
@@ -1036,7 +1040,7 @@ class Time(Item, time):
 
         self._raw = raw
 
-    def unwrap(self) -> datetime:
+    def unwrap(self) -> time:
         (hour, minute, second, microsecond, tzinfo, _, _) = self._getstate()
         return time(hour, minute, second, microsecond, tzinfo)
 
@@ -1157,7 +1161,7 @@ class Array(Item, _CustomList):
         groups.append(this_group)
         return [group for group in groups if group]
 
-    def unwrap(self) -> str:
+    def unwrap(self) -> List[Any]:
         unwrapped = []
         for v in self:
             if isinstance(v, Item):
@@ -1427,7 +1431,7 @@ class AbstractTable(Item, _CustomDict):
             if k is not None:
                 dict.__setitem__(self, k.key, v)
 
-    def unwrap(self):
+    def unwrap(self) -> Dict[str, Any]:
         unwrapped = {}
         for k, v in self.items():
             if isinstance(k, Key):
@@ -1822,7 +1826,7 @@ class AoT(Item, _CustomList):
         for table in body:
             self.append(table)
 
-    def unwrap(self) -> str:
+    def unwrap(self) -> List[Dict[str, Any]]:
         unwrapped = []
         for t in self._body:
             if isinstance(t, Item):
@@ -1922,7 +1926,7 @@ class Null(Item):
     def __init__(self) -> None:
         pass
 
-    def unwrap(self) -> str:
+    def unwrap(self) -> None:
         return None
 
     @property

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import string
 
@@ -470,6 +471,7 @@ class Parser:
                     # datetime
                     try:
                         dt = parse_rfc3339(raw)
+                        assert isinstance(dt, datetime.datetime)
                         return DateTime(
                             dt.year,
                             dt.month,
@@ -488,6 +490,7 @@ class Parser:
                 if m.group(1):
                     try:
                         dt = parse_rfc3339(raw)
+                        assert isinstance(dt, datetime.date)
                         date = Date(dt.year, dt.month, dt.day, trivia, raw)
                         self.mark()
                         while self._current not in "\t\n\r#,]}" and self.inc():
@@ -499,6 +502,7 @@ class Parser:
                             return date
 
                         dt = parse_rfc3339(raw + time_raw)
+                        assert isinstance(dt, datetime.datetime)
                         return DateTime(
                             dt.year,
                             dt.month,
@@ -517,6 +521,7 @@ class Parser:
                 if m.group(5):
                     try:
                         t = parse_rfc3339(raw)
+                        assert isinstance(t, datetime.time)
                         return Time(
                             t.hour,
                             t.minute,
@@ -678,10 +683,10 @@ class Parser:
             or sign
             and raw.startswith(".")
         ):
-            return
+            return None
 
         if raw.startswith(("0o", "0x", "0b")) and sign:
-            return
+            return None
 
         digits = "[0-9]"
         base = 10
@@ -699,14 +704,14 @@ class Parser:
         clean = re.sub(f"(?i)(?<={digits})_(?={digits})", "", raw).lower()
 
         if "_" in clean:
-            return
+            return None
 
         if (
             clean.endswith(".")
             or not clean.startswith("0x")
             and clean.split("e", 1)[0].endswith(".")
         ):
-            return
+            return None
 
         try:
             return Integer(int(sign + clean, base), trivia, sign + raw)
@@ -714,7 +719,7 @@ class Parser:
             try:
                 return Float(float(sign + clean), trivia, sign + raw)
             except ValueError:
-                return
+                return None
 
     def _parse_literal_string(self) -> String:
         with self._state:


### PR DESCRIPTION
When using `tomlkit` in type-annotated projects, some `unwrap()` methods have wrong return-type signatures.
Also running `mypy` in the current source tree reports many errors; this PR tries to fix some low-hanging fruits by introducing type-narrowing with `assert isinstance(...)`.
