### PR TITLE
Add Python 3.11 release candidate 2 to the testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", 3.11-dev]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11.0-rc - 3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Poetry
         shell: bash
         run: |
-          curl -fsSL https://install.python-poetry.org | python - -y --version 1.1.15
+          curl -fsSL https://install.python-poetry.org | python - -y --version 1.2.1
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
       - uses: pre-commit/action@v2.0.3
   Tests:
     needs: Linting
@@ -24,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", 3.11-dev]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Poetry
         shell: bash
-        if: ! startsWith(matrix.python-version, '3.11')
+        if: !startsWith(matrix.python-version, '3.11')
         run: |
           curl -fsSL https://install.python-poetry.org | python - -y --version 1.1.15
       - if: startsWith(matrix.python-version, '3.11')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,9 @@ jobs:
       - name: Install Poetry
         shell: bash
         run: |
-          curl -fsSL https://install.python-poetry.org | python - -y --version 1.2.1
+          curl -fsSL https://install.python-poetry.org | python - -y --version 1.1.15
+      - if: startsWith(matrix.python-version, '3.11')
+        run: curl -fsSL https://install.python-poetry.org | python - -y --version 1.2.1
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Install Poetry
         shell: bash
+        if: ! startsWith(matrix.python-version, '3.11')
         run: |
           curl -fsSL https://install.python-poetry.org | python - -y --version 1.1.15
       - if: startsWith(matrix.python-version, '3.11')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [Ubuntu, MacOS, Windows]
         python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11.0-rc - 3.11"]


### PR DESCRIPTION
Python 3.11 will be on average 22% faster than Python 3.10 so let’s give it a spin... https://www.python.org/download/pre-releases

Related to #237