### PR TITLE
allow broader type for toml file path value

### DIFF
--- a/tomlkit/toml_file.py
+++ b/tomlkit/toml_file.py
@@ -2,15 +2,16 @@ import os
 import re
 
 from typing import TYPE_CHECKING
-from typing import Union
 
 from tomlkit.api import loads
 from tomlkit.toml_document import TOMLDocument
 
 
 if TYPE_CHECKING:
-    _StrPath = Union[str, os.PathLike[str]]
+    from _typeshed import StrPath as _StrPath
 else:
+    from typing import Union
+
     _StrPath = Union[str, os.PathLike]
 
 

--- a/tomlkit/toml_file.py
+++ b/tomlkit/toml_file.py
@@ -1,8 +1,17 @@
 import os
 import re
 
+from typing import TYPE_CHECKING
+from typing import Union
+
 from tomlkit.api import loads
 from tomlkit.toml_document import TOMLDocument
+
+
+if TYPE_CHECKING:
+    _StrPath = Union[str, os.PathLike[str]]
+else:
+    _StrPath = Union[str, os.PathLike]
 
 
 class TOMLFile:
@@ -12,7 +21,7 @@ class TOMLFile:
     :param path: path to the TOML file
     """
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: _StrPath) -> None:
         self._path = path
         self._linesep = os.linesep
 


### PR DESCRIPTION
Since `tomlkit` supports Python 3.6 and onwards now, `os.PathLike` can be supported as the additional type for `path` argument in `TOMLFile` constructor. This PR adds the necessary bits.

Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>