### PR TITLE
Configure Read The Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+---
+
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+# for details
+
+version: 2
+
+sphinx:
+  builder: dirhtml
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: >-
+      3.11
+
+python:
+  install:
+  - method: pip
+    path: .
+  - requirements: docs/requirements.txt
+  system_packages: false
+
+...

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,8 +35,6 @@ TOML File
 TOML Items
 ----------
 
-.. module:: tomlkit.items
-
 .. automodule:: tomlkit.items
    :show-inheritance:
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,4 +57,4 @@ html_theme = "furo"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -119,7 +119,7 @@ def string(
     boolean flags (e.g. ``literal=True`` and/or ``multiline=True``)
     can be used for personalization.
 
-    For more information, please check the spec: `https://toml.io/en/v1.0.0#string`_.
+    For more information, please check the spec: `<https://toml.io/en/v1.0.0#string>`__.
 
     Common escaping rules will be applied for basic strings.
     This can be controlled by explicitly setting ``escape=False``.


### PR DESCRIPTION
This patch includes minimal configuration and fixes for the Sphinx warnings, making it possible to make the RTD builds succeed.

Fixes #161

Build log in the fork: https://readthedocs.org/projects/tomlkit-webknjazs-fork/builds/18578470/
Demo: https://tomlkit-webknjazs-fork.readthedocs.io/en/maintenance-rtd-config/