### PR TITLE
fix: delete inline table element does not leave trailing sep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - Parse empty table name if it is quoted. ([#258](https://github.com/sdispater/tomlkit/issues/258))
+- Fix a bug that remove last element of an Inline Table leaves a comma. ([#259](https://github.com/sdispater/tomlkit/issues/259))
 - Fix the `unwrap()` method for `Container` children values which sometimes returns an internal object if the table is an out-of-order table. ([#264](https://github.com/sdispater/tomlkit/issues/264))
 
 ## [0.11.6] - 2022-10-27

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -824,7 +824,7 @@ def test_trim_comments_when_building_inline_table():
     assert table.as_string() == '{foo = "bar", baz = "foobaz"}'
 
 
-def test_deleting_inline_table_elemeent_does_not_leave_trailing_separator():
+def test_deleting_inline_table_element_does_not_leave_trailing_separator():
     table = api.inline_table()
     table["foo"] = "bar"
     table["baz"] = "boom"
@@ -843,6 +843,22 @@ def test_deleting_inline_table_elemeent_does_not_leave_trailing_separator():
     table["baz"] = "boom"
 
     assert table.as_string() == '{baz = "boom"}'
+
+
+def test_deleting_inline_table_element_does_not_leave_trailing_separator2():
+    doc = parse('a = {foo = "bar", baz = "boom"}')
+    table = doc["a"]
+    assert table.as_string() == '{foo = "bar", baz = "boom"}'
+
+    del table["baz"]
+    assert table.as_string() == '{foo = "bar" }'
+
+    del table["foo"]
+    assert table.as_string() == "{ }"
+
+    table["baz"] = "boom"
+
+    assert table.as_string() == '{ baz = "boom"}'
 
 
 def test_booleans_comparison():

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1719,6 +1719,14 @@ class InlineTable(AbstractTable):
 
     def as_string(self) -> str:
         buf = "{"
+        last_item_idx = next(
+            (
+                i
+                for i in range(len(self._value.body) - 1, -1, -1)
+                if self._value.body[i][0] is not None
+            ),
+            None,
+        )
         for i, (k, v) in enumerate(self._value.body):
             if k is None:
                 if i == len(self._value.body) - 1:
@@ -1741,7 +1749,7 @@ class InlineTable(AbstractTable):
                 f"{v_trivia_trail}"
             )
 
-            if i != len(self._value.body) - 1:
+            if last_item_idx is not None and i < last_item_idx:
                 buf += ","
                 if self._new:
                     buf += " "


### PR DESCRIPTION
Fix #259