### PR TITLE
TDD: Add failing tests for #273

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -311,6 +311,14 @@ def test_add_dotted_key():
     table.add(tomlkit.key(["foo", "bar"]), 1)
     assert table.as_string() == "foo.bar = 1\n"
 
+# See https://github.com/sdispater/tomlkit/issues/273
+def test_dotted_and_not_dotted_keys():
+    table = tomlkit.table()
+    table.add("foo", 1)
+    table.add(tomlkit.key(["bar", "baz"]), 2)
+    table.add(tomlkit.key(["bar", "qux"]), 3)
+    assert table.as_string() == "foo = 1\nbar.baz = 2\nbar.qux = 3\n"
+
 
 @pytest.mark.parametrize(
     ("raw", "expected"),


### PR DESCRIPTION
This introduces tests for #273 with no implementation yet (Test-Driven Development).

I am not sure how to fix this however: should `_table_keys` have been populated with `"bar"` before the crash?