### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you are using [Poetry](https://poetry.eustace.io),
 add `tomlkit` to your `pyproject.toml` file by using:
 
 ```bash
+pip install poetry
 poetry add tomlkit
 ```
 


### PR DESCRIPTION
A small addition by specifing that poetry should be installed by pip before using poetry install.