### PR TITLE
README: Link to readthedocs for the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Part of the implementation has been adapted, improved and fixed from [Molten](ht
 
 ## Usage
 
-See the [documentation](https://github.com/sdispater/tomlkit/blob/master/docs/quickstart.rst) for more information.
+See the [documentation](https://tomlkit.readthedocs.io/) for more information.
 
 ## Installation
 


### PR DESCRIPTION
For the Quickstart it doesn't make a huge difference, but it is important for the API documentation.