### PR TITLE
perf: only iter on found escape sequences

### DIFF
--- a/tomlkit/_utils.py
+++ b/tomlkit/_utils.py
@@ -133,9 +133,11 @@ def escape_string(s: str, escape_sequences: Collection[str] = _basic_escapes) ->
 
         return i + inc
 
+    found_sequences = {seq for seq in escape_sequences if seq in s}
+
     i = 0
     while i < len(s):
-        for seq in escape_sequences:
+        for seq in found_sequences:
             seq_len = len(seq)
             if s[i:].startswith(seq):
                 start = flush(seq_len)


### PR DESCRIPTION
Finding used sequences is much faster than iterating over each one of them for each character.

The iteration is still used, but at least it will only be used once per any sequence that is actually used in the string.

Most strings won't include any sequences and will just be fast.

@moduon MT-1075