### PR TITLE
fix(#305): generate setup.py file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ include = [
   { path = "CHANGELOG.md", format = "sdist" },
 ]
 
+[tool.poetry.build]
+generate-setup-file = true
+
 [tool.poetry.dependencies]
 python = ">=3.7"
 


### PR DESCRIPTION
Since poetry 1.3.0 setup.py files are no longer generated by default. See https://python-poetry.org/blog/announcing-poetry-1.3.0/#generate-setup-file--false

This causes an issue where in order to build `tomlkit` we need to use `poetry` itself.