### PR TITLE
fix: replace deprecated usage of datetime.utcnow

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -2,11 +2,11 @@ import copy
 import math
 import pickle
 
-from datetime import UTC
 from datetime import date
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
+from datetime import timezone
 
 import pytest
 
@@ -104,7 +104,7 @@ def test_true_unwrap():
 
 
 def test_datetime_unwrap():
-    dt = datetime.now(tz=UTC)
+    dt = datetime.now(tz=timezone.utc)
     elementary_test(item(dt), datetime)
 
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -2,6 +2,7 @@ import copy
 import math
 import pickle
 
+from datetime import UTC
 from datetime import date
 from datetime import datetime
 from datetime import time
@@ -103,7 +104,7 @@ def test_true_unwrap():
 
 
 def test_datetime_unwrap():
-    dt = datetime.utcnow()
+    dt = datetime.now(tz=UTC)
     elementary_test(item(dt), datetime)
 
 


### PR DESCRIPTION
Fixes #297

Signed-off-by: Frost Ming <me@frostming.com>