### PR TITLE
Fix division for integers

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -624,6 +624,10 @@ def test_integers_behave_like_ints():
     assert i == 33
     assert i.as_string() == "33"
 
+    i /= 2
+    assert i == 16.5
+    assert i.as_string() == "16.5"
+
     doc = parse("int = +34")
     doc["int"] += 1
 

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -667,11 +667,21 @@ class Integer(Item, _CustomInt):
     __rpow__ = wrap_method(int.__rpow__)
     __rrshift__ = wrap_method(int.__rrshift__)
     __rshift__ = wrap_method(int.__rshift__)
-    __rtruediv__ = wrap_method(int.__rtruediv__)
     __rxor__ = wrap_method(int.__rxor__)
-    __truediv__ = wrap_method(int.__truediv__)
     __trunc__ = wrap_method(int.__trunc__)
     __xor__ = wrap_method(int.__xor__)
+
+    def __rtruediv__(self, other):
+        result = int.__rtruediv__(self, other)
+        if result is NotImplemented:
+            return result
+        return Float._new(self, result)
+
+    def __truediv__(self, other):
+        result = int.__truediv__(self, other)
+        if result is NotImplemented:
+            return result
+        return Float._new(self, result)
 
 
 class Float(Item, _CustomFloat):


### PR DESCRIPTION
This is a possible fix for https://github.com/sdispater/tomlkit/issues/309. Changes introduced in https://github.com/sdispater/tomlkit/pull/307 made it so that the float result of division on an Integer is wrapped as an Integer, which is incorrect.

I have included a test case which demonstrates the issue.