### PR TITLE
fix: Dumping a subelement of a parsed toml fails starting on 4rd level of nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix repeated whitespace when removing an array item. ([#405](https://github.com/python-poetry/tomlkit/issues/405))
 - Fix invalid serialization after removing array item if the comma is on its own line. ([#408](https://github.com/python-poetry/tomlkit/issues/408))
+- Fix serialization of a nested dotted key table. ([#411](https://github.com/python-poetry/tomlkit/issues/411))
 - Refine the error message when use non-string as single key. ([#412](https://github.com/python-poetry/tomlkit/issues/412))
 - Fix invalid serialization after overwriting a key of a out-of-order table. ([#414](https://github.com/python-poetry/tomlkit/issues/414))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -181,6 +181,12 @@ def test_dump_to_file_object():
     assert fp.getvalue() == 'foo = "bar"\n'
 
 
+def test_dump_nested_dotted_table():
+    a = tomlkit.parse("a.b.c.d='e'")["a"]
+    assert a == {"b": {"c": {"d": "e"}}}
+    assert dumps(a) == "b.c.d='e'"
+
+
 def test_integer():
     i = tomlkit.integer("34")
 

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -50,7 +50,9 @@ def dumps(data: Mapping, sort_keys: bool = False) -> str:
     """
     Dumps a TOMLDocument into a string.
     """
-    if not isinstance(data, Container) and isinstance(data, Mapping):
+    if not isinstance(data, (Table, InlineTable, Container)) and isinstance(
+        data, Mapping
+    ):
         data = item(dict(data), _sort_keys=sort_keys)
 
     try:
@@ -58,7 +60,7 @@ def dumps(data: Mapping, sort_keys: bool = False) -> str:
         # for all type safe invocations of this function
         return data.as_string()  # type: ignore[attr-defined]
     except AttributeError as ex:
-        msg = f"Expecting Mapping or TOML Container, {type(data)} given"
+        msg = f"Expecting Mapping or TOML Table or Container, {type(data)} given"
         raise TypeError(msg) from ex
 
 


### PR DESCRIPTION
Fixes #411

Signed-off-by: Frost Ming <me@frostming.com>