### PR TITLE
Honor sort_keys for parsed TOML documents

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -166,6 +166,12 @@ def test_mapping_types_can_be_dumped() -> None:
     assert dumps(x) == 'foo = "bar"\n'
 
 
+def test_parsed_document_can_be_dumped_with_sorted_keys() -> None:
+    doc = loads('zzz = 1\naaa = "foo"')
+
+    assert dumps(doc, sort_keys=True) == 'aaa = "foo"\nzzz = 1\n'
+
+
 def test_dumps_weird_object() -> None:
     with pytest.raises(TypeError):
         dumps(object())  # type: ignore[arg-type]

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -58,9 +58,12 @@ def dumps(data: Mapping[str, Any], sort_keys: bool = False) -> str:
     Dumps a TOMLDocument into a string.
     """
     if isinstance(data, (Table, InlineTable, Container)):
-        return data.as_string()
+        if not sort_keys:
+            return data.as_string()
 
-    table: Table = item(dict(data), _sort_keys=sort_keys)
+        return item(data, _sort_keys=True).as_string()
+
+    table = item(dict(data), _sort_keys=sort_keys)
     return table.as_string()
 
 


### PR DESCRIPTION
## Summary
- honor `sort_keys=True` when dumping parsed `TOMLDocument` / container values
- keep the existing fast path for unsorted container dumps
- add regression coverage for `loads()` + `dumps(sort_keys=True)`

Closes #466.

## Validation
Autoresearch-style binary gates:
- E1 baseline repro exists: `tomlkit.dumps(tomlkit.loads('zzz = 1\naaa = "foo"'), sort_keys=True)` preserved the original order on `master`
- E2 regression expectation fails on baseline: the new test expects sorted output for a parsed document
- E3 regression passes after fix: parsed documents now dump as `'aaa = "foo"\nzzz = 1\n'`
- E4 targeted tests pass:
  - `python3 -m pytest tests/test_api.py -k 'sorted_keys or raw_dict_can_be_dumped or mapping_types_can_be_dumped'`
- E5 broader nearby suite passes:
  - `python3 -m pytest tests/test_api.py`

## Notes
The fix only changes the `sort_keys=True` container path. Unsorted container dumps still use the existing direct `as_string()` fast path.
