### PR TITLE
Fix inline table separator after append

### DIFF
--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -923,6 +923,14 @@ def test_deleting_inline_table_element_does_not_leave_trailing_separator2() -> N
     assert table.as_string() == '{ baz = "boom"}'
 
 
+def test_appending_to_parsed_inline_table_preserves_separator() -> None:
+    doc = parse("a = { foo = 1, bar = 2 }\n")
+    doc["a"]["baz"] = 3
+
+    assert doc.as_string() == "a = { foo = 1, bar = 2, baz = 3}\n"
+    parse(doc.as_string())
+
+
 def test_booleans_comparison() -> None:
     boolean = Bool(True, Trivia())
 

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -2037,6 +2037,7 @@ class InlineTable(AbstractTable):
     def as_string(self) -> str:
         buf = "{"
         emitted_key = False
+        needs_separator = False
         has_explicit_commas = any(
             k is None and isinstance(v, Whitespace) and "," in v.s
             for k, v in self._value.body
@@ -2073,9 +2074,17 @@ class InlineTable(AbstractTable):
                     elif not has_explicit_commas or "," in v.as_string():
                         buf = buf.rstrip(",")
 
-                buf += v.as_string()
+                v_string = v.as_string()
+                buf += v_string
+                if "," in v_string:
+                    needs_separator = False
 
                 continue
+
+            if has_explicit_commas and needs_separator:
+                stripped = buf.rstrip()
+                buf = f"{stripped},{buf[len(stripped):]}"
+                needs_separator = False
 
             v_trivia_trail = v.trivia.trail.replace("\n", "")
             buf += (
@@ -2087,6 +2096,8 @@ class InlineTable(AbstractTable):
                 f"{v_trivia_trail}"
             )
             emitted_key = True
+            if has_explicit_commas:
+                needs_separator = True
 
             if (
                 not has_explicit_commas

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -2083,7 +2083,7 @@ class InlineTable(AbstractTable):
 
             if has_explicit_commas and needs_separator:
                 stripped = buf.rstrip()
-                buf = f"{stripped},{buf[len(stripped):]}"
+                buf = f"{stripped},{buf[len(stripped) :]}"
                 needs_separator = False
 
             v_trivia_trail = v.trivia.trail.replace("\n", "")


### PR DESCRIPTION
## Summary

Fix inline table serialization after appending a new key to a parsed inline table that already preserved explicit comma tokens.

The serializer now tracks whether an emitted key still needs a separator. When a later mutation adds a key without an explicit comma token, `as_string()` inserts the missing comma before rendering the next key.

Fixes #476.

## Tests

- `python3 -m pytest tests/test_items.py::test_appending_to_parsed_inline_table_preserves_separator tests/test_items.py::test_deleting_inline_table_element_does_not_leave_trailing_separator tests/test_items.py::test_deleting_inline_table_element_does_not_leave_trailing_separator2 tests/test_items.py::test_items_can_be_appended_to_and_removed_from_an_inline_table -q`
- `python3 -m pytest tests -q`
- `git diff --check`