### PR TITLE
Fix duplicated comma when removing a middle inline table element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Fixed
+
+- Fix invalid serialization with a duplicated comma when removing a non-edge element from a parsed inline table. ([#486](https://github.com/python-poetry/tomlkit/pull/486))
+
 ## [0.15.0] - 2026-05-10
 
 ### Changed

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -931,6 +931,19 @@ def test_appending_to_parsed_inline_table_preserves_separator() -> None:
     parse(doc.as_string())
 
 
+def test_deleting_inline_table_middle_element_does_not_leave_double_separator() -> None:
+    doc = parse("a = {foo = 1, bar = 2, baz = 3}\n")
+    del doc["a"]["bar"]
+
+    # The dangling separator left by the removed key must not produce an
+    # invalid ``, ,`` sequence; the result must round-trip.
+    rendered = doc.as_string()
+    assert ", ," not in rendered
+    assert ",," not in rendered
+    assert parse(rendered) == {"a": {"foo": 1, "baz": 3}}
+    assert parse(rendered).as_string() == rendered
+
+
 def test_booleans_comparison() -> None:
     boolean = Bool(True, Trivia())
 

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -2050,6 +2050,7 @@ class InlineTable(AbstractTable):
             ),
             None,
         )
+        pending_separator = False
         for i, (k, v) in enumerate(self._value.body):
             if k is None:
                 if isinstance(v, Whitespace) and "," in v.s:
@@ -2067,6 +2068,15 @@ class InlineTable(AbstractTable):
                     if has_following_null and not has_following_key:
                         buf += v.as_string().replace(",", "", 1)
                         continue
+
+                    if pending_separator:
+                        # A previous key was removed, leaving this comma as a
+                        # duplicate of an already emitted separator. Drop it to
+                        # avoid producing an invalid ``, ,`` sequence.
+                        buf += v.as_string().replace(",", "", 1)
+                        continue
+
+                    pending_separator = True
 
                 if i == len(self._value.body) - 1:
                     if self._new:
@@ -2096,6 +2106,7 @@ class InlineTable(AbstractTable):
                 f"{v_trivia_trail}"
             )
             emitted_key = True
+            pending_separator = False
             if has_explicit_commas:
                 needs_separator = True
 


### PR DESCRIPTION
## Summary

Removing a key that is neither the first nor the last element of a **parsed** inline table leaves the dangling comma separator from the deleted key in the body, producing invalid TOML that fails to re-parse.

```python
import tomlkit

doc = tomlkit.parse("t = {a = 1, b = 2, c = 3}\n")
del doc["t"]["b"]
print(doc.as_string())
# -> 't = {a = 1, , c = 3}\n'   <-- invalid: a stray ", ,"

tomlkit.parse(doc.as_string())
# tomlkit.exceptions.UnexpectedCharError: Unexpected character: ',' at line 1 col 12
```

The serialized output is not valid TOML and breaks the parse → mutate → dump round-trip.

## Root cause

When a key is removed from a parsed inline table, its value becomes a `Null` and the two `Whitespace` separators that surrounded it remain in `Container.body`. `InlineTable.as_string()` already strips one comma in a couple of special cases (the leading separator before the first emitted key, and a trailing separator when only `Null` values follow), but it had no handling for the *middle* case: a removed interior key leaves two consecutive comma-bearing whitespace entries, so both commas are emitted and you get `, ,`.

## Fix

`InlineTable.as_string()` now tracks a `pending_separator` flag. Once a comma separator has been emitted for the current gap, the next comma-bearing whitespace entry encountered before the next real key is recognized as the redundant separator left behind by the removed key and its comma is dropped. The flag is reset whenever an actual key is emitted, so legitimate separators between surviving keys are preserved.

This mirrors the existing comma-stripping pattern already used in the same method (`v.as_string().replace(",", "", 1)`).

## Tests

Added `test_deleting_inline_table_middle_element_does_not_leave_double_separator`, which deletes a middle key from a parsed inline table and asserts the result contains no `, ,`/`,,` sequence, re-parses to the expected value, and is idempotent (`parse(s).as_string() == s`). The test fails on `master` and passes with this change.

The full suite is green:

```
$ pytest -q tests
969 passed
```

`ruff check`, `ruff format --check`, `mypy`, and all `pre-commit` hooks pass on the changed files.

## Notes

This is the deletion counterpart to the append fix in #477 (issue #476) and is distinct from the last-element trailing-comma case (#259) — both of those are already handled; only interior deletion was missing.
