### PR TITLE
Add native __contains__ to Container, Table and InlineTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Speed up membership tests (`key in container`) with a native `Container.__contains__`, avoiding the inherited `MutableMapping` round-trip through `__getitem__` (which resolves the value and builds an exception on every absent key). ([#483](https://github.com/python-poetry/tomlkit/issues/483))
+- Speed up membership tests (`key in ...`) on `Container`, `Table` and `InlineTable` with native `__contains__` implementations, avoiding the inherited `MutableMapping` round-trip through `__getitem__` (which resolves the value and builds an exception on every absent key). ([#483](https://github.com/python-poetry/tomlkit/issues/483))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Changed
+
+- Speed up membership tests (`key in container`) with a native `Container.__contains__`, avoiding the inherited `MutableMapping` round-trip through `__getitem__` (which resolves the value and builds an exception on every absent key). ([#483](https://github.com/python-poetry/tomlkit/issues/483))
+
 ### Fixed
 
 - Fix invalid serialization with a duplicated comma when removing a non-edge element from a parsed inline table. ([#486](https://github.com/python-poetry/tomlkit/pull/486))

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1233,3 +1233,51 @@ def test_array_item_removal_newline_restore_next() -> None:
     doc["x"].remove("1")
     assert doc.as_string() == expected
     parse(doc.as_string())
+
+
+def test_table_membership_matches_inner_container() -> None:
+    doc = parse('[server]\nhost = "localhost"\nport = 8080\nenabled = true\n')
+    table = doc["server"]
+    assert isinstance(table, Table)
+
+    assert "host" in table
+    assert "port" in table
+    assert "enabled" in table
+    assert "missing" not in table
+
+    # ``str`` and ``Key`` arguments behave identically.
+    assert Key("host") in table
+    assert Key("missing") not in table
+
+    # The native ``__contains__`` must agree with the inner container it delegates to.
+    for key in ("host", "port", "enabled", "missing", ""):
+        assert (key in table) == (key in table.value)
+
+    # A non-string / non-Key key still raises, as before.
+    with pytest.raises(TypeError):
+        table.__contains__(42)
+
+
+def test_inline_table_membership() -> None:
+    doc = parse("point = {x = 1, y = 2}")
+    inline = doc["point"]
+    assert isinstance(inline, InlineTable)
+
+    assert "x" in inline
+    assert "y" in inline
+    assert "z" not in inline
+    assert Key("y") in inline
+
+
+def test_out_of_order_table_membership() -> None:
+    content = '[a.a]\nkey = "value"\n\n[a.b]\n\n[a.a.c]\n'
+    doc = parse(content)
+    table = doc["a"]
+
+    # ``a`` is stored out of order (a tuple index in the inner container): the
+    # only non-trivial ``__contains__`` branch, where an ``OutOfOrderTableProxy``
+    # is built. Membership must be correct and must not mutate the document.
+    assert "a" in table
+    assert "b" in table
+    assert "missing" not in table
+    assert doc.as_string() == content

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -714,6 +714,23 @@ class Container(_CustomDict):  # type: ignore[type-arg]
 
         return item
 
+    def __contains__(self, key: object) -> bool:
+        # Native membership test. The inherited ``MutableMapping.__contains__``
+        # resolves the value via ``__getitem__``/``item()`` (and builds a
+        # ``NonExistentKey`` on every absent key) only to discard it. Resolve the
+        # key the same way ``item()`` does -- ``str`` becomes a ``SingleKey``
+        # (a non-str/non-``Key`` argument still raises ``TypeError``) -- then
+        # probe ``_map`` directly. For an out-of-order table the proxy is still
+        # built so its validation runs exactly as before.
+        if not isinstance(key, Key):
+            key = SingleKey(key)  # type: ignore[arg-type]
+        idx = self._map.get(key)
+        if idx is None:
+            return False
+        if isinstance(idx, tuple):
+            OutOfOrderTableProxy(self, idx)
+        return True
+
     def __setitem__(self, key: Key | str, value: Any) -> None:
         if key in self:
             old_key = next(filter(lambda k: k == key, self._map))

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1818,6 +1818,15 @@ class AbstractTable(Item, _CustomDict):  # type: ignore[type-arg]
     def __getitem__(self, key: Key | str) -> Any:  # type: ignore[override]
         return self._value[key]
 
+    def __contains__(self, key: object) -> bool:
+        # Native membership test. The inherited ``MutableMapping.__contains__``
+        # resolves the value via ``__getitem__`` (``self._value[key]``) -- and
+        # builds a ``NonExistentKey`` on every absent key -- only to discard it.
+        # Delegate straight to the inner container instead: its ``__contains__``
+        # answers from ``_map`` while still building the ``OutOfOrderTableProxy``
+        # for an out-of-order entry, so validation runs exactly as before.
+        return key in self._value
+
     def __setitem__(self, key: Key | str, value: Any) -> None:  # type: ignore[override]
         if not isinstance(value, Item):
             value = item(value, _parent=self)


### PR DESCRIPTION
## Summary

First of the small, self-contained, conformance-preserving performance changes discussed in #483 — now also covering `Table` / `InlineTable` per @frostming's review question.

Both `Container` and the table types (`Table`, `InlineTable`, via `AbstractTable`) inherit `__contains__` from `MutableMapping`, so `key in x` goes through `self[key]` → `__getitem__` → `item()`, which resolves and returns the value — and constructs a `NonExistentKey` exception on every *absent* key — only to discard it.

**`Container`** gets a native `__contains__` that resolves the key exactly as `item()` does (`str` → `SingleKey`; a non-`str`/non-`Key` argument still raises `TypeError`) and probes `self._map` directly. For an out-of-order table (a tuple index) it still builds the `OutOfOrderTableProxy`, so its validation runs exactly as before. This also speeds up `Container.__setitem__`, which does `if key in self` on every assignment.

**`Table` / `InlineTable`** get a native `AbstractTable.__contains__` that delegates to the inner container (`return key in self._value`). The inherited mixin never reached the native `Container.__contains__` (it went through `__getitem__`), so the table types didn't benefit transitively; delegating fixes that while still building the `OutOfOrderTableProxy` for an out-of-order entry, so validation is unchanged.

## Behaviour — no change

Beyond the existing suite, I ran a differential `in` check (present / absent / out-of-order / dotted-string / `Key`-vs-`str` / non-`str` keys) comparing this branch against `master`, for both `Container` and the table types: identical results, including the `TypeError` on a non-string key and the out-of-order proxy path. A regression test on an out-of-order super-table is included.

## Benchmark

Drift-immune A/B in a single process (native `__contains__` vs the inherited `__getitem__`-based path, interleaved so thermal drift cancels), CPython 3.11:

```
Container (mixed present + absent keys):
  inherited via __getitem__: ~610 ms
  native __contains__:       ~520 ms     → ~1.17x faster

Table / InlineTable membership (key in table):
  present key: ~1.2x faster
  absent key:  ~1.8x faster   (the miss path is where the discarded
                               NonExistentKey construction dominates)
```

## Verification

- `pytest tests/` (incl. the `toml-test` conformance submodule): **972 passed** (969 on `master` + 3 new membership tests), no regressions.
- `ruff check` + `ruff format --check`: clean.
- `mypy` (1.19.1): no new errors. The single `# type: ignore[arg-type]` (in `Container.__contains__`) mirrors the existing `SingleKey(key)` call in `item()`.
- The 3 new membership tests were validated by focused mutation testing — every mutant of the new `__contains__` is killed, and an equivalent mutant correctly survives.

---

<sub>Context: this is harness-assisted work — every change is individually benchmarked and gated (full test suite incl. conformance, a differential guard, ruff + mypy) before it can land, and I review and stand behind each PR personally. Happy to slice the rest of #483 into further small PRs — e.g. the same native `__contains__` for `OutOfOrderTableProxy` (a separate base class), or the bulk char-scanning / header-cache work.</sub>
