### PR TITLE
Bulk-scan single-line string bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Speed up membership tests (`key in ...`) on `Container`, `Table` and `InlineTable` with native `__contains__` implementations, avoiding the inherited `MutableMapping` round-trip through `__getitem__` (which resolves the value and builds an exception on every absent key). ([#483](https://github.com/python-poetry/tomlkit/issues/483))
 - Speed up parsing by making `Source` index-based: it now tracks an integer position over the input string instead of materializing a list of `(index, char)` tuples up front, so construction is O(1) and state save/restore no longer copies an iterator. ([#489](https://github.com/python-poetry/tomlkit/pull/489))
 - Speed up parsing by scanning character runs in bulk: `Source.advance_while`/`advance_until` consume a whole run of whitespace, bare-key or number characters in a single pass over the input string instead of one `inc()` call per character. ([#490](https://github.com/python-poetry/tomlkit/pull/490))
+- Speed up parsing of single-line strings by bulk-appending the run of ordinary characters up to the next delimiter, backslash or control character in one pass, instead of one character at a time. ([#491](https://github.com/python-poetry/tomlkit/pull/491))
 
 ### Fixed
 

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -64,6 +64,14 @@ _SPACES_SET = frozenset(TOMLChar.SPACES)
 _BARE_KEY_OR_SPACE = frozenset(TOMLChar.BARE + TOMLChar.SPACES)
 _NUM_STOP = frozenset(" \t\n\r#,]}")
 _DATE_TAIL_STOP = frozenset("\t\n\r#,]}")
+# Control chars invalid inside a single-line string (DEL + everything <= 0x1F
+# except tab) — exactly the set that raises InvalidControlChar in the per-char
+# string loop. The single-line string-body fast-path stops its bulk scan at the
+# first delimiter / backslash / control char, then the main loop handles that
+# char with its existing branch (raising InvalidControlChar where needed).
+_CTRL_SINGLE = frozenset(chr(c) for c in range(0x20) if c != CTRL_I) | {chr(CHR_DEL)}
+_SINGLE_LITERAL_STOP = _CTRL_SINGLE | {"'"}  # literal: only the closing quote
+_SINGLE_BASIC_STOP = _CTRL_SINGLE | {'"', "\\"}  # basic: quote or escape
 
 
 class Parser:
@@ -836,6 +844,16 @@ class Parser:
                 if cur == "\r\n":
                     self.inc_n(2, exception=UnexpectedEofError)
 
+        # PERF: stop-set for the single-line string-body bulk fast-path (None for
+        # multiline, which keeps the per-char loop because of \r\n handling).
+        src = self._src
+        EOF = src.EOF
+        single_stop = None
+        if delim.is_singleline():
+            single_stop = (
+                _SINGLE_BASIC_STOP if delim.is_basic() else _SINGLE_LITERAL_STOP
+            )
+
         escaped = False  # whether the previous key was ESCAPE
         while True:
             code = ord(self._current)
@@ -911,10 +929,24 @@ class Parser:
             else:
                 # this is either a literal string where we keep everything as is,
                 # or this is not a special escaped char in a basic string
-                value += self._current
+                if single_stop is not None:
+                    # PERF fast-path: bulk-append the run of ordinary characters
+                    # up to the next delimiter / backslash / control char, instead
+                    # of one `value += cur; inc()` iteration per character. The
+                    # stop char is then handled by the branches above on the next
+                    # iteration (single-line only; multiline keeps the per-char
+                    # loop for CRLF handling).
+                    run_start = src._idx
+                    src.advance_until(single_stop)
+                    if src._current is EOF:
+                        # mid-string EOF — same error as the per-char inc()
+                        raise self.parse_error(UnexpectedEofError)
+                    value += src[run_start : src._idx]
+                else:
+                    value += self._current
 
-                # consume this char, EOF here is an issue (middle of string)
-                self.inc(exception=UnexpectedEofError)
+                    # consume this char, EOF here is an issue (middle of string)
+                    self.inc(exception=UnexpectedEofError)
 
     def _parse_table(
         self, parent_name: Key | None = None, parent: Table | None = None


### PR DESCRIPTION
> **Stacked on #489 and #490** — the first two commits here are those PRs (index-based `Source` + bulk run scanning). Best reviewed/merged after them; GitHub will collapse this to just the string-scan commit once they land. Happy to rebase.

## What

Parsing a single-line string appended its body **one character at a time** (`value += current; inc()`). For long string values (the bulk of most config / lockfile content) this dominates.

This scans the run of ordinary characters up to the next delimiter, backslash or control character in a single pass (`Source.advance_until`) and appends the whole slice at once; the stop character is then handled by the existing branch on the next iteration. Multiline strings keep the per-character loop (CRLF handling).

The stop-set is **exactly** the control characters the per-character loop rejects, so `InvalidControlChar` / escape / delimiter handling is unchanged, and a mid-string EOF raises `UnexpectedEofError` just as the per-char `inc(exception=...)` did.

## Benchmarks

Parsing speedup across document shapes (median, interleaved A/B vs `master`, includes #489+#490):

| document | speedup |
|---|---|
| large flat, single-line string values (~90 KB) | 4.9× |
| pyproject.toml | 2.1× |
| poetry.lock-like (~64 KB) | 2.1× |
| typical mixed (~4 KB) | 1.5× |

No regression on any shape (multiline-heavy and nested docs are unchanged).

## Tests

Full suite passes (972 tests, incl. the toml-test conformance submodule). On top of that, a **4135-input adversarial differential** (random escapes valid+invalid, every control byte 0x00–0x1F+DEL in basic & literal, unicode/astral/combining, the other-quote char inside strings, truncated/malformed inputs for error parity) is **byte-identical** in output and exception type to the per-character loop. No public API or behaviour change.