### PR TITLE
reject surrogate code points in \U unicode escapes

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,7 @@ import pytest
 
 from tomlkit.exceptions import EmptyTableNameError
 from tomlkit.exceptions import InternalParserError
+from tomlkit.exceptions import InvalidUnicodeValueError
 from tomlkit.exceptions import UnexpectedCharError
 from tomlkit.items import StringType
 from tomlkit.parser import Parser
@@ -63,3 +64,19 @@ def test_parse_multiline_literal_string_with_crlf() -> None:
     content = "a = '''foo\r\nbar'''"
     parser = Parser(content)
     assert parser.parse() == {"a": "foo\r\nbar"}
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        r'a = "\uD800"',
+        r'a = "\uDFFF"',
+        r'a = "\U0000D800"',
+        r'a = "\U0000DFFF"',
+        r'a = "\U0000DC00"',
+    ],
+)
+def test_parser_rejects_surrogate_unicode_escapes(content: str) -> None:
+    parser = Parser(content)
+    with pytest.raises(InvalidUnicodeValueError):
+        parser.parse()

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -1165,11 +1165,19 @@ class Parser:
             else:
                 extracted = self.extract()
 
-                if extracted[0].lower() == "d" and extracted[1].strip("01234567"):
-                    return None, None
+                try:
+                    codepoint = int(extracted, 16)
+                except ValueError:
+                    return None, extracted
+
+                # Unicode scalar values exclude the surrogate range
+                # (U+D800 to U+DFFF). The 8-digit \U form reaches this range
+                # with leading zeros, so it must be checked on the value itself.
+                if 0xD800 <= codepoint <= 0xDFFF:
+                    return None, extracted
 
                 try:
-                    value = chr(int(extracted, 16))
+                    value = chr(codepoint)
                 except (ValueError, OverflowError):
                     value = None
 


### PR DESCRIPTION
1. `_peek_unicode` detects surrogates from the first two hex digits, which only matches the 4-digit `\u` form.
2. The 8-digit `\U` form reaches the surrogate range with leading zeros (`\U0000D800`), so the check is skipped and the escape is accepted as a lone surrogate that fails UTF-8 encoding.
3. Test the decoded code point against U+D800..U+DFFF instead, so both forms are rejected with `InvalidUnicodeValueError`.

Valid boundaries (U+D7FF, U+E000) and astral code points still parse; added a regression test.