### PR TITLE
reject tab characters in bare keys

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,7 @@ import pytest
 from tomlkit.exceptions import EmptyTableNameError
 from tomlkit.exceptions import InternalParserError
 from tomlkit.exceptions import InvalidUnicodeValueError
+from tomlkit.exceptions import ParseError
 from tomlkit.exceptions import UnexpectedCharError
 from tomlkit.items import StringType
 from tomlkit.parser import Parser
@@ -79,4 +80,18 @@ def test_parse_multiline_literal_string_with_crlf() -> None:
 def test_parser_rejects_surrogate_unicode_escapes(content: str) -> None:
     parser = Parser(content)
     with pytest.raises(InvalidUnicodeValueError):
+        parser.parse()
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "a\tb = 1",
+        "[a\tb]",
+        "x.y\tz = 1",
+    ],
+)
+def test_parser_rejects_tab_in_bare_key(content: str) -> None:
+    parser = Parser(content)
+    with pytest.raises(ParseError):
         parser.parse()

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -426,8 +426,8 @@ class Parser:
             # Empty key
             raise self.parse_error(EmptyKeyError)
 
-        if " " in key_s:
-            # Bare key with spaces in it
+        if " " in key_s or "\t" in key_s:
+            # Bare key with whitespace in it
             raise self.parse_error(ParseError, f'Invalid key "{key_s}"')
 
         result: Key = SingleKey(key_s, KeyType.Bare, "", original)


### PR DESCRIPTION
1. `_parse_bare_key` consumes spaces and tabs while reading a bare key, then strips outer whitespace and only rejects the key if it still contains a literal space, so an interior tab is never caught.
2. As a result bare keys, dotted-key segments and table names with embedded tabs are accepted (`a\tb = 1`, `[a\tb]`, `x.y\tz = 1`), which the spec disallows and which stdlib `tomllib` and the official toml-test corpus reject.

Changed the check to reject the key when the stripped value contains a space or a tab. Validation stays in the parser since callers receive the already-built key.

Verified against the failing inputs above, the existing parser tests, and the full toml-test suite. Added a regression test that fails before the change and passes after.