### PR TITLE
Fix doubled comma when inserting into a comma-first array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fix invalid serialization with a duplicated comma when removing a non-edge element from a parsed inline table. ([#486](https://github.com/python-poetry/tomlkit/pull/486))
+- Fix invalid serialization with a duplicated comma when appending or inserting into a comma-first formatted array. ([#499](https://github.com/python-poetry/tomlkit/pull/499))
 
 ## [0.15.0] - 2026-05-10
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -944,6 +944,48 @@ def test_deleting_inline_table_middle_element_does_not_leave_double_separator() 
     assert parse(rendered).as_string() == rendered
 
 
+def test_appending_to_comma_first_array_does_not_double_separator() -> None:
+    doc = parse(
+        """\
+a = [
+      1 # one
+     ,2
+    ]
+"""
+    )
+    doc["a"].append(99)
+
+    # The comma separating ``2`` from ``99`` is carried by the new item's
+    # comma-first indent; adding a trailing comma to ``2`` as well would
+    # produce an invalid ``2,\\n,99`` sequence.
+    rendered = doc.as_string()
+    assert parse(rendered)["a"] == [1, 2, 99]
+    assert parse(rendered).as_string() == rendered
+
+
+def test_inserting_into_comma_first_array_does_not_double_separator() -> None:
+    doc = parse(
+        """\
+a = [
+      1 # one
+     ,2
+    ]
+"""
+    )
+    doc["a"].insert(1, 99)
+
+    rendered = doc.as_string()
+    assert parse(rendered)["a"] == [1, 99, 2]
+    assert parse(rendered).as_string() == rendered
+
+    # Inserting at the front copies the first item's comma-less indent and
+    # must keep its usual trailing comma.
+    doc["a"].insert(0, 0)
+    rendered = doc.as_string()
+    assert parse(rendered)["a"] == [0, 1, 99, 2]
+    assert parse(rendered).as_string() == rendered
+
+
 def test_booleans_comparison() -> None:
     boolean = Bool(True, Trivia())
 

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -1635,9 +1635,21 @@ class Array(Item, _CustomList):  # type: ignore[type-arg]
                 # Copy the comma from the last item if 1) it contains a value and
                 # 2) the array is multiline
                 comma = last_item.comma
-            if last_item.comma is None and not isinstance(last_item.value, Null):
-                # Add comma to the last item to separate it from the following items.
+            comma_in_indent = indent is not None and "," in indent.s
+            if (
+                last_item.comma is None
+                and not isinstance(last_item.value, Null)
+                and not comma_in_indent
+            ):
+                # Add comma to the last item to separate it from the following
+                # items, unless the new item's indent already starts with a
+                # comma (comma-first style).
                 last_item.comma = Whitespace(",")
+        if indent is not None and "," in indent.s:
+            # Comma-first style: the item that will follow the new one brings
+            # its own leading comma, so the new item must not add a trailing
+            # comma of its own.
+            comma = None
         if indent is None and (idx > 0 or "\n" in default_indent):
             # apply default indent if it isn't the first item or the array is multiline.
             indent = Whitespace(default_indent)


### PR DESCRIPTION
Fixes #494.

In a comma-first formatted array the comma that separates an item from the previous one lives in that item's *indent* whitespace (the parser folds `\n ,` into the next group's indent when a comment ends the previous group). `Array.insert()` copies such an indent onto the new item, but then also adds a trailing comma to the previous item — and for middle inserts gives the new item a trailing comma too — so the output contains double separators and no longer parses:

```python
doc = tomlkit.parse("a = [\n      1 # one\n     ,2\n    ]\n")
doc["a"].append(99)
tomlkit.parse(tomlkit.dumps(doc))  # UnexpectedCharError: ',' — dumped "2,\n     ,99"
```

The fix skips both extra commas when the indent copied onto the new item already carries one: the embedded comma is the separator. Output is style-preserving (`,2` → `,99`) and round-trips. Same structure as the `__delitem__` `comma_in_indent` handling from #486, which `insert()` never got.

Regression tests cover append, middle insert (both previously produced unparseable output), and front insert (comma-less indent, unchanged behavior).
