### PR TITLE
Fix corrupt output when adding to a dotted key inside an inline table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix invalid serialization with a duplicated comma when removing a non-edge element from a parsed inline table. ([#486](https://github.com/python-poetry/tomlkit/pull/486))
 - Fix invalid serialization with a duplicated comma when appending or inserting into a comma-first formatted array. ([#499](https://github.com/python-poetry/tomlkit/pull/499))
+- Fix unparseable serialization when adding a key to a dotted-key table inside an inline table. ([#500](https://github.com/python-poetry/tomlkit/pull/500))
 
 ## [0.15.0] - 2026-05-10
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -944,6 +944,28 @@ def test_deleting_inline_table_middle_element_does_not_leave_double_separator() 
     assert parse(rendered).as_string() == rendered
 
 
+def test_adding_to_dotted_key_inside_inline_table() -> None:
+    doc = parse("a = {b.c = 1}\n")
+    doc["a"]["b"]["d"] = 2
+
+    # The added key must stay attached to the ``b.`` prefix and be separated
+    # from the existing pair; the result must round-trip.
+    rendered = doc.as_string()
+    assert rendered == "a = {b.c = 1, b.d = 2}\n"
+    assert parse(rendered) == {"a": {"b": {"c": 1, "d": 2}}}
+    assert parse(rendered).as_string() == rendered
+
+
+def test_adding_to_nested_dotted_key_inside_inline_table() -> None:
+    doc = parse("a = {b.c.e = 1}\n")
+    doc["a"]["b"]["c"]["g"] = 2
+
+    rendered = doc.as_string()
+    assert rendered == "a = {b.c.e = 1, b.c.g = 2}\n"
+    assert parse(rendered) == {"a": {"b": {"c": {"e": 1, "g": 2}}}}
+    assert parse(rendered).as_string() == rendered
+
+
 def test_appending_to_comma_first_array_does_not_double_separator() -> None:
     doc = parse(
         """\

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -2118,14 +2118,18 @@ class InlineTable(AbstractTable):
                 needs_separator = False
 
             v_trivia_trail = v.trivia.trail.replace("\n", "")
-            buf += (
-                f"{v.trivia.indent}"
-                f"{k.as_string() + ('.' if k.is_dotted() else '')}"
-                f"{k.sep}"
-                f"{v.as_string()}"
-                f"{v.trivia.comment}"
-                f"{v_trivia_trail}"
-            )
+            if k.is_dotted() and isinstance(v, Table):
+                # A table materialized from a dotted key renders one
+                # `prefix.child = value` pair per child, so that keys added
+                # after parsing stay attached to the dotted prefix.
+                rendered = ", ".join(self._render_dotted(k, v))
+            else:
+                rendered = (
+                    f"{k.as_string() + ('.' if k.is_dotted() else '')}"
+                    f"{k.sep}"
+                    f"{v.as_string()}"
+                )
+            buf += f"{v.trivia.indent}{rendered}{v.trivia.comment}{v_trivia_trail}"
             emitted_key = True
             pending_separator = False
             if has_explicit_commas:
@@ -2143,6 +2147,25 @@ class InlineTable(AbstractTable):
         buf += "}"
 
         return buf
+
+    def _render_dotted(self, key: Key, table: Table) -> list[str]:
+        """Render a table materialized from a dotted key as a list of
+        ``prefix.child = value`` strings, recursing into nested dotted
+        children."""
+        prefix = f"{key.as_string()}.{key.sep}"
+        parts = []
+        for k, v in table.value.body:
+            if k is None:
+                continue
+            if isinstance(v, Table):
+                parts.extend(f"{prefix}{sub}" for sub in self._render_dotted(k, v))
+            else:
+                trail = v.trivia.trail.replace("\n", "")
+                parts.append(
+                    f"{prefix}{v.trivia.indent}{k.as_string()}{k.sep}{v.as_string()}"
+                    f"{v.trivia.comment_ws}{v.trivia.comment}{trail}"
+                )
+        return parts
 
     def __setitem__(self, key: Key | str, value: Any) -> None:  # type: ignore[override]
         if hasattr(value, "trivia") and value.trivia.comment:


### PR DESCRIPTION
Adding a key to a dotted-key table inside an inline table produced unparseable output (#495):

```python
doc = parse('a = {b.c = 1}\n')
doc["a"]["b"]["d"] = 2
doc.as_string()  # 'a = {b.c = 1d = 2\n}'
```

`InlineTable.as_string` rendered the dotted prefix once and then dumped the materialized table's block-style body verbatim. The fix renders one `prefix.child = value` pair per child (recursing for nested dotted keys), mirroring what `Container._render_table` does for dotted keys in regular tables, so the result is `a = {b.c = 1, b.d = 2}`. Repeating the prefix is required for correctness: rendering the new key bare (`{b.c = 1, d = 2}`) would change its meaning to `a.d`.

Fixes #495.