### PR TITLE
reject non-hex digits in \u and \U escapes

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -86,6 +86,23 @@ def test_parser_rejects_surrogate_unicode_escapes(content: str) -> None:
 @pytest.mark.parametrize(
     "content",
     [
+        r'a = "\u12_3"',
+        r'a = "\u 123"',
+        r'a = "\u+123"',
+        r'a = "\u1_23"',
+        r'a = "\U0010_FFFF"',
+        r'a = "\U0000_0041"',
+    ],
+)
+def test_parser_rejects_non_hex_unicode_escapes(content: str) -> None:
+    parser = Parser(content)
+    with pytest.raises(InvalidUnicodeValueError):
+        parser.parse()
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
         "a\tb = 1",
         "[a\tb]",
         "x.y\tz = 1",

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -1163,10 +1163,10 @@ class Parser:
             else:
                 extracted = self.extract()
 
-                try:
-                    codepoint = int(extracted, 16)
-                except ValueError:
+                if extracted.strip("0123456789abcdefABCDEF"):
                     return None, extracted
+
+                codepoint = int(extracted, 16)
 
                 # Unicode scalar values exclude the surrogate range
                 # (U+D800 to U+DFFF). The 8-digit \U form reaches this range


### PR DESCRIPTION
1. `_peek_unicode` converts the 4 (`\u`) or 8 (`\U`) characters after the prefix with `int(extracted, 16)`, but never checks they are hex digits the way the sibling `_peek_hex` does.
2. `int(s, 16)` silently accepts underscores between digits, a leading sign, and surrounding whitespace, so escapes like `\u12_3`, `\u+123`, `\u 123` and `\U0010_FFFF` decode to an arbitrary code point instead of being rejected.
3. Validate the extracted characters with the same `strip` check used by `_peek_hex` before converting; valid escapes and the surrogate-range handling are unchanged. Added a regression test.