### PR TITLE
Compare StringType members by identity instead of building a set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Speed up parsing by scanning character runs in bulk: `Source.advance_while`/`advance_until` consume a whole run of whitespace, bare-key or number characters in a single pass over the input string instead of one `inc()` call per character. ([#490](https://github.com/python-poetry/tomlkit/pull/490))
 - Speed up parsing of single-line strings by bulk-appending the run of ordinary characters up to the next delimiter, backslash or control character in one pass, instead of one character at a time. ([#491](https://github.com/python-poetry/tomlkit/pull/491))
 - Speed up parsing by removing the internal `TOMLChar` wrapper: the parser now reads plain `str` characters from `Source` and detects end-of-input positionally, avoiding a per-character object construction and method dispatch. ([#492](https://github.com/python-poetry/tomlkit/pull/492))
+- Speed up parsing by comparing `StringType` members by identity (`is`) instead of building a set on every `is_basic`/`is_literal`/`is_singleline`/`is_multiline` call, avoiding millions of enum hashes while parsing. ([#502](https://github.com/python-poetry/tomlkit/pull/502))
 
 ### Fixed
 

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -280,16 +280,16 @@ class StringType(Enum):
         return self.value[0]
 
     def is_basic(self) -> bool:
-        return self in {StringType.SLB, StringType.MLB}
+        return self is StringType.SLB or self is StringType.MLB
 
     def is_literal(self) -> bool:
-        return self in {StringType.SLL, StringType.MLL}
+        return self is StringType.SLL or self is StringType.MLL
 
     def is_singleline(self) -> bool:
-        return self in {StringType.SLB, StringType.SLL}
+        return self is StringType.SLB or self is StringType.SLL
 
     def is_multiline(self) -> bool:
-        return self in {StringType.MLB, StringType.MLL}
+        return self is StringType.MLB or self is StringType.MLL
 
     def toggle(self) -> StringType:
         return {


### PR DESCRIPTION
## What

`StringType.is_basic` / `is_literal` / `is_singleline` / `is_multiline` each did `self in {StringType.X, StringType.Y}`, which builds a set and hashes enum members on **every** call. These run for essentially every string and value parsed, so profiling a mixed document (a `poetry.lock`-like file + `pyproject.toml` + flat keys) shows millions of `Enum.__hash__` calls originating here.

Compare by identity instead (enum members are singletons) — same result, no per-call set construction or hashing.

## Benchmarks

Parsing speedup (median, interleaved A/B vs `master`):

| document | speedup |
|---|---|
| `pyproject.toml`-like | ~1.15× |
| large flat keys/values | ~1.14× |
| string-heavy | ~1.13× |
| `poetry.lock`-like | ~1.06× |

## Tests

Full suite passes (toml-test conformance submodule included). No public API or behaviour change — round-trip output is byte-identical to `master`.