### PR TITLE
Merge super tables in place instead of deep-copying on every merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Speed up parsing of single-line strings by bulk-appending the run of ordinary characters up to the next delimiter, backslash or control character in one pass, instead of one character at a time. ([#491](https://github.com/python-poetry/tomlkit/pull/491))
 - Speed up parsing by removing the internal `TOMLChar` wrapper: the parser now reads plain `str` characters from `Source` and detects end-of-input positionally, avoiding a per-character object construction and method dispatch. ([#492](https://github.com/python-poetry/tomlkit/pull/492))
 - Speed up parsing by comparing `StringType` members by identity (`is`) instead of building a set on every `is_basic`/`is_literal`/`is_singleline`/`is_multiline` call, avoiding millions of enum hashes while parsing. ([#502](https://github.com/python-poetry/tomlkit/pull/502))
+- Speed up merging super tables by merging in place instead of deep-copying the growing target on every merge, turning the parse of documents with many subtables under a shared super table (e.g. consecutive `[a.b.c]` / `[a.b.d]` headers) from O(n²) into O(n). ([#503](https://github.com/python-poetry/tomlkit/pull/503))
 
 ### Fixed
 

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -258,17 +258,16 @@ class Container(_CustomDict):  # type: ignore[type-arg]
 
                             return self
 
-                        # Create a new element to replace the old one
-                        current = copy.deepcopy(current)
+                        # Merge the new super table's body into the existing one
+                        # in place. Previously this deep-copied `current` before
+                        # appending, which is O(size of current) on every merge
+                        # and therefore O(n^2) when many subtables share a super
+                        # table (e.g. consecutive `[a.b.c]` / `[a.b.d]` headers).
+                        # Mutating in place is O(1) per merge. The defensive copy
+                        # that protected the out-of-order validation pass has been
+                        # moved into OutOfOrderTableProxy (its only consumer).
                         for k, v in item.value.body:
                             current.append(k, v)
-                        self._body[
-                            (
-                                current_idx[-1]
-                                if isinstance(current_idx, tuple)
-                                else current_idx
-                            )
-                        ] = (current_body_element[0], current)
 
                         return self
                     elif (
@@ -902,14 +901,20 @@ class OutOfOrderTableProxy(_CustomDict):  # type: ignore[type-arg]
     @staticmethod
     def validate(container: Container, indices: tuple[int, ...]) -> None:
         """Validate out of order tables in the given container"""
-        # Append all items to a temp container to see if there is any error
+        # Append all items to a temp container to see if there is any error.
+        # We deep-copy each value before appending: appending a super table
+        # merges it in place into a matching one already in temp_container, and
+        # those values are the live subtables of `container`. Without the copy
+        # the merge would mutate the caller's tables (and corrupt a later
+        # validation pass). The container merge itself is now copy-free for
+        # speed, so this is where the isolation lives.
         temp_container = Container(True)
         for i in indices:
             _, item = container._body[i]
 
             if isinstance(item, Table):
                 for k, v in item.value.body:
-                    temp_container.append(k, v, validate=True)
+                    temp_container.append(k, copy.deepcopy(v), validate=True)
 
         temp_container._validate_out_of_order_table()
 


### PR DESCRIPTION
## What

When a super table is merged into an existing one, `Container.append` deep-copied the existing target before appending the incoming branch:

```python
current = copy.deepcopy(current)
for k, v in item.value.body:
    current.append(k, v)
self._body[idx] = (key, current)
```

That copy is `O(size of current)`, and because the target accumulates every sibling that is merged into it, parsing a document with many subtables under a shared super table becomes **O(n²)** in the number of siblings. This is common in generated config / lock-style files with headers like `[a.b.c]`, `[a.b.d]`, `[a.b.e]`, …

Merging in place is `O(1)` per merge, so the parse is `O(n)` overall.

The deep copy only existed to stop the **out-of-order validation** pass from mutating the live tables it walks (`OutOfOrderTableProxy.validate` builds a temp container by appending those tables' bodies, which itself merges them). The isolating copy is therefore moved into that consumer, where it runs once for genuinely out-of-order tables instead of on every in-order merge.

## Benchmark

Parsing `n` subtables under a shared super table (`[s.r0.…]` … `[s.rN.…]`), median:

| n | before | after | speedup |
|---:|---:|---:|---:|
| 20 | 19 ms | 2.0 ms | ×9.7 |
| 80 | 300 ms | 8.2 ms | ×36 |
| 160 | 1243 ms | 16.5 ms | ×75 |
| 320 | 5326 ms | 34 ms | ×157 |

The growing speedup is the O(n²)→O(n) change. A realistic mixed document (`data.toml`) parses ~12% faster; nothing regresses.

## Tests

Full suite incl. the toml-test conformance submodule passes. No public API or behaviour change — round-trip output is byte-identical to `master`, verified by a differential over many nested / out-of-order / dotted-key / AoT documents (including `.add()` mutations on nested tables).