### PR TITLE
Move a value replacing a table out of the table region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix invalid serialization with a duplicated comma when removing a non-edge element from a parsed inline table. ([#486](https://github.com/python-poetry/tomlkit/pull/486))
 - Fix invalid serialization with a duplicated comma when appending or inserting into a comma-first formatted array. ([#499](https://github.com/python-poetry/tomlkit/pull/499))
 - Fix unparseable serialization when adding a key to a dotted-key table inside an inline table. ([#500](https://github.com/python-poetry/tomlkit/pull/500))
+- Fix a table replaced by a plain value being serialized inside the preceding table's body when other tables follow; the value now moves before the first table like other root-level values. ([#504](https://github.com/python-poetry/tomlkit/issues/504))
 
 ## [0.15.0] - 2026-05-10
 

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -831,6 +831,33 @@ a = 1
     )
 
 
+def test_replace_middle_table_with_value() -> None:
+    # https://github.com/python-poetry/tomlkit/issues/504
+    content = """[a]
+aa = 1
+
+[b]
+bb = 2
+
+[c]
+cc = 3
+"""
+    doc = parse(content)
+    doc["b"] = 2
+    assert (
+        doc.as_string()
+        == """b = 2
+
+[a]
+aa = 1
+
+[c]
+cc = 3
+"""
+    )
+    assert parse(doc.as_string())["a"] == {"aa": 1}
+
+
 def test_replace_preserve_sep() -> None:
     content = """a   =   1
 

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -783,14 +783,21 @@ class Container(_CustomDict):  # type: ignore[type-arg]
             dict.__delitem__(self, k.key)
 
         if isinstance(value, (AoT, Table)) != isinstance(v, (AoT, Table)):
-            # new tables should appear after all non-table values
             self.remove(k)
-            for i in range(idx, len(self._body)):
-                if isinstance(self._body[i][1], (AoT, Table)):
-                    self._insert_at(i, new_key, value)
-                    idx = i
-                    break
+            if isinstance(value, (AoT, Table)):
+                # new tables should appear after all non-table values
+                for i in range(idx, len(self._body)):
+                    if isinstance(self._body[i][1], (AoT, Table)):
+                        self._insert_at(i, new_key, value)
+                        idx = i
+                        break
+                else:
+                    idx = -1
+                    self.append(new_key, value)
             else:
+                # the replaced table's slot lies in the table region, where a
+                # plain value would be captured by the preceding table on
+                # round-trip; append() puts it with the other root-level values
                 idx = -1
                 self.append(new_key, value)
         else:


### PR DESCRIPTION
Fixes #504.

`Container._replace_at` used the same forward scan for both kind-change directions. It was written for value→table ("new tables should appear after all non-table values"), but for table→value it inserted the plain value just before the *next* table header — textually inside the preceding table's body — so on round-trip the key became a child of that table. The last-table case already worked because the scan fell through to `append()`; this routes the whole table→value direction through `append()`, which places values before the first table like any other root-level value.