### PR TITLE
Restore dumps() delegating to as_string for non-Mapping wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix invalid serialization with a duplicated comma when appending or inserting into a comma-first formatted array. ([#499](https://github.com/python-poetry/tomlkit/pull/499))
 - Fix unparseable serialization when adding a key to a dotted-key table inside an inline table. ([#500](https://github.com/python-poetry/tomlkit/pull/500))
 - Fix a table replaced by a plain value being serialized inside the preceding table's body when other tables follow; the value now moves before the first table like other root-level values. ([#504](https://github.com/python-poetry/tomlkit/issues/504))
+- Restore `dumps()` rendering mapping-like wrappers around a parsed document (e.g. `dotty_dict`'s `Dotty`) through their delegated `as_string`, preserving the original table order and layout instead of re-encoding through a plain dict — a 0.15.0 regression. ([#482](https://github.com/python-poetry/tomlkit/issues/482))
 
 ## [0.15.0] - 2026-05-10
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -166,6 +166,25 @@ def test_mapping_types_can_be_dumped() -> None:
     assert dumps(x) == 'foo = "bar"\n'
 
 
+def test_dumps_wrapper_delegating_as_string_preserves_layout() -> None:
+    """Mapping-like wrappers around a parsed document dump it verbatim (#482)."""
+
+    class DocumentWrapper:
+        """Bare-bones stand-in for wrappers such as dotty_dict's Dotty."""
+
+        def __init__(self, document: TOMLDocument) -> None:
+            self._document = document
+
+        def __getitem__(self, key: str) -> Any:
+            return self._document[key]
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._document, name)
+
+    content = '[tool.a]\nx = 1\n\n[project]\nname = "demo"\n\n[tool.b]\ny = 2\n'
+    assert dumps(DocumentWrapper(parse(content))) == content  # type: ignore[arg-type]
+
+
 def test_parsed_document_can_be_dumped_with_sorted_keys() -> None:
     doc = loads('zzz = 1\naaa = "foo"')
 

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -63,8 +63,18 @@ def dumps(data: Mapping[str, Any], sort_keys: bool = False) -> str:
 
         return item(data, _sort_keys=True).as_string()
 
-    table = item(dict(data), _sort_keys=sort_keys)
-    return table.as_string()
+    if isinstance(data, Mapping):
+        return item(dict(data), _sort_keys=sort_keys).as_string()
+
+    try:
+        # mapping-like wrappers (e.g. dotty_dict's Dotty) delegate
+        # ``as_string`` to the document they wrap; rendering it directly
+        # preserves the original layout, which re-encoding through a plain
+        # dict would lose
+        return data.as_string()  # type: ignore[attr-defined]
+    except AttributeError as ex:
+        msg = f"Expecting Mapping or TOML Table or Container, {type(data)} given"
+        raise TypeError(msg) from ex
 
 
 def load(fp: IO[str] | IO[bytes]) -> TOMLDocument:


### PR DESCRIPTION
Fixes #482.

Since 0.15.0, `dumps()` on a mapping-like wrapper around a parsed document (e.g. `dotty_dict.Dotty`, which python-semantic-release uses) re-encodes through `item(dict(data))`. That coalesces out-of-order tables — in the issue's pyproject, `[project]` ends up after all the `[tool.*]` sections — and inserts extra blank lines. 0.14.0 dumped the same input byte-identically because its non-Mapping fallback called `data.as_string()`, which such wrappers delegate to the wrapped document; that fallback was dropped in the #460 typing refactor.

This restores the 0.14.0 contract: real Mappings still re-encode (honoring `sort_keys`), non-Mapping objects fall back to their `as_string`, and anything else gets the friendly `TypeError` back (currently it surfaces as an opaque `'X' object is not iterable` from `dict(data)`).

The regression test uses a minimal stand-in wrapper, so no dotty_dict test dependency; verified red on master.
