### PR TITLE
Limit parser nesting depth instead of crashing with RecursionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix unparseable serialization when adding a key to a dotted-key table inside an inline table. ([#500](https://github.com/python-poetry/tomlkit/pull/500))
 - Fix a table replaced by a plain value being serialized inside the preceding table's body when other tables follow; the value now moves before the first table like other root-level values. ([#504](https://github.com/python-poetry/tomlkit/issues/504))
 - Restore `dumps()` rendering mapping-like wrappers around a parsed document (e.g. `dotty_dict`'s `Dotty`) through their delegated `as_string`, preserving the original table order and layout instead of re-encoding through a plain dict — a 0.15.0 regression. ([#482](https://github.com/python-poetry/tomlkit/issues/482))
+- Fix uncontrolled recursion when parsing deeply nested documents: crafted input could crash the process with a `RecursionError`. Values nested more than 100 levels deep and keys with more than 100 dotted fragments now raise `ParseError`. ([#459](https://github.com/python-poetry/tomlkit/issues/459))
 
 ## [0.15.0] - 2026-05-10
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,6 +37,7 @@ from tomlkit.items import Integer
 from tomlkit.items import Key
 from tomlkit.items import Table
 from tomlkit.items import Time
+from tomlkit.parser import Parser
 from tomlkit.toml_document import TOMLDocument
 
 
@@ -503,3 +504,28 @@ def test_parse_empty_quoted_table_name() -> None:
     parsed = loads(content)
     assert parsed == {"": {"x": 1}}
     assert dumps(parsed) == content
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "x = " + "[" * 500 + "1" + "]" * 500,
+        "x = " + "{a = " * 500 + "1" + "}" * 500,
+        "x = " + "[{a = " * 500 + "1" + "}]" * 500,
+        ".".join(["a"] * 500) + " = 1",
+        "[" + ".".join(["a"] * 500) + "]\nx = 1",
+        "[[" + ".".join(["a"] * 500) + "]]\nx = 1",
+    ],
+)
+def test_parse_rejects_deeply_nested_documents(payload: str) -> None:
+    """Nesting beyond the depth limit raises ParseError, not RecursionError."""
+    with pytest.raises(tomlkit.exceptions.ParseError):
+        parse(payload)
+
+
+def test_parse_accepts_nesting_at_the_depth_limit() -> None:
+    depth = Parser.MAX_NESTING_DEPTH
+    array = "x = " + "[" * depth + "1" + "]" * depth
+    assert parse(array).as_string() == array
+    dotted = ".".join(["a"] * depth) + " = 1"
+    assert parse(dotted).as_string() == dotted

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -5,6 +5,7 @@ import re
 import string
 
 from typing import Any
+from typing import Callable
 
 from tomlkit._compat import decode
 from tomlkit._utils import RFC_3339_LOOSE
@@ -82,11 +83,17 @@ class Parser:
     Parser for TOML documents.
     """
 
+    # Deeply nested documents would overflow the interpreter stack: arrays and
+    # inline tables are parsed recursively, and every fragment of a dotted key
+    # adds a level of nested containers. Refuse documents beyond this depth.
+    MAX_NESTING_DEPTH = 100
+
     def __init__(self, string: str | bytes) -> None:
         # Input to parse
         self._src = Source(decode(string))
 
         self._aot_stack: list[Key] = []
+        self._nesting_depth = 0
 
     @property
     def _state(self) -> _StateHandler:
@@ -390,6 +397,24 @@ class Parser:
         Parses a Key at the current position;
         WS before the key must be exhausted first at the callsite.
         """
+        key = self._parse_simple_key()
+        fragments = 1
+        while self._current == ".":
+            fragments += 1
+            if fragments > self.MAX_NESTING_DEPTH:
+                raise self.parse_error(
+                    ParseError,
+                    f"TOML key nested more than {self.MAX_NESTING_DEPTH} levels deep",
+                )
+            self.inc()
+            key = key.concat(self._parse_simple_key())
+
+        return key
+
+    def _parse_simple_key(self) -> Key:
+        """
+        Parses a single (non-dotted) key fragment.
+        """
         self.mark()
         # Skip any leading whitespace (bulk scan)
         self._src.advance_while(_SPACES)
@@ -419,12 +444,8 @@ class Parser:
         self.mark()
         self._src.advance_while(_SPACES)
         original += self.extract()
-        result: Key = SingleKey(str(key_str), t=key_type, sep="", original=original)
-        if self._current == ".":
-            self.inc()
-            result = result.concat(self._parse_key())
 
-        return result
+        return SingleKey(str(key_str), t=key_type, sep="", original=original)
 
     def _parse_bare_key(self) -> Key:
         """
@@ -442,13 +463,7 @@ class Parser:
             # Bare key with whitespace in it
             raise self.parse_error(ParseError, f'Invalid key "{key_s}"')
 
-        result: Key = SingleKey(key_s, KeyType.Bare, "", original)
-
-        if self._current == ".":
-            self.inc()
-            result = result.concat(self._parse_key())
-
-        return result
+        return SingleKey(key_s, KeyType.Bare, "", original)
 
     def _parse_value(self) -> Item:
         """
@@ -467,9 +482,9 @@ class Parser:
         elif c == BoolType.FALSE.value[0]:
             return self._parse_false()
         elif c == "[":
-            return self._parse_array()
+            return self._parse_nested(self._parse_array)
         elif c == "{":
-            return self._parse_inline_table()
+            return self._parse_nested(self._parse_inline_table)
         elif c in "+-" or self._peek(4) in {
             "+inf",
             "-inf",
@@ -587,6 +602,21 @@ class Parser:
                 self.consume(c, min=1, max=1)
 
             return Bool(style, Trivia())
+
+    def _parse_nested(self, parse: Callable[[], Item]) -> Item:
+        """
+        Parses an array or inline table, enforcing the nesting depth limit.
+        """
+        self._nesting_depth += 1
+        if self._nesting_depth > self.MAX_NESTING_DEPTH:
+            raise self.parse_error(
+                ParseError,
+                f"TOML value nested more than {self.MAX_NESTING_DEPTH} levels deep",
+            )
+        try:
+            return parse()
+        finally:
+            self._nesting_depth -= 1
 
     def _parse_array(self) -> Array:
         # Consume opening bracket, EOF here is an issue (middle of array)


### PR DESCRIPTION
Fixes #459 (picking this up since #468 went stale).

Crafted input could crash the process with a `RecursionError` via three unbounded recursion paths: nested arrays, nested inline tables, and dotted keys (every fragment recursed through `_parse_key`/`_parse_bare_key`, which the issue didn't mention but has the same effect — `'a.'*10000 + 'a = 1'` also crashed). Values nested more than 100 levels deep and keys with more than 100 dotted fragments now raise `ParseError` with position info; `MAX_NESTING_DEPTH` is a class attribute so subclasses can override it.

Dotted-key parsing is now a loop instead of recursion (the chain is linear, and `concat` flattening is associative so left-to-right building produces identical keys); the cap is still needed there because each fragment creates a level of nested containers and operations like `Container.parsing()` recurse over that tree. Documents at exactly the limit still parse and round-trip — covered in the tests, which all fail with `RecursionError` on master.