### PR TITLE
Add a native OutOfOrderTableProxy.__contains__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Speed up parsing by removing the internal `TOMLChar` wrapper: the parser now reads plain `str` characters from `Source` and detects end-of-input positionally, avoiding a per-character object construction and method dispatch. ([#492](https://github.com/python-poetry/tomlkit/pull/492))
 - Speed up parsing by comparing `StringType` members by identity (`is`) instead of building a set on every `is_basic`/`is_literal`/`is_singleline`/`is_multiline` call, avoiding millions of enum hashes while parsing. ([#502](https://github.com/python-poetry/tomlkit/pull/502))
 - Speed up merging super tables by merging in place instead of deep-copying the growing target on every merge, turning the parse of documents with many subtables under a shared super table (e.g. consecutive `[a.b.c]` / `[a.b.d]` headers) from O(n²) into O(n). ([#503](https://github.com/python-poetry/tomlkit/pull/503))
+- Speed up membership tests (`key in ...`) on out-of-order tables with a native `OutOfOrderTableProxy.__contains__`, completing [#483](https://github.com/python-poetry/tomlkit/issues/483) for the last mapping type that still inherited the slow `MutableMapping` mixin (which resolves the value and builds an exception on every absent key). ([#515](https://github.com/python-poetry/tomlkit/pull/515))
 
 ### Fixed
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -19,6 +19,7 @@ from tests.util import assert_is_ppo
 from tests.util import elementary_test
 from tomlkit import api
 from tomlkit import parse
+from tomlkit.container import OutOfOrderTableProxy
 from tomlkit.exceptions import NonExistentKey
 from tomlkit.items import Array
 from tomlkit.items import Bool
@@ -1344,4 +1345,25 @@ def test_out_of_order_table_membership() -> None:
     assert "a" in table
     assert "b" in table
     assert "missing" not in table
+    assert doc.as_string() == content
+
+
+def test_out_of_order_table_proxy_membership() -> None:
+    # A top-level table split by another table (``a`` interrupted by ``foo``)
+    # resolves to an ``OutOfOrderTableProxy``; exercise its native
+    # ``__contains__`` directly (the test above goes through ``Table``).
+    content = "[a.x]\np = 1\n[foo]\nbar = 2\n[a.y]\nq = 3\n"
+    doc = parse(content)
+    table = doc["a"]
+    assert isinstance(table, OutOfOrderTableProxy)
+
+    assert "x" in table
+    assert "y" in table
+    assert "missing" not in table
+    # a Key is accepted just like __getitem__ does
+    assert Key("x") in table
+    # a non-str/non-Key argument is rejected like the other mapping types
+    with pytest.raises(TypeError):
+        _ = 123 in table
+    # membership must not resolve values or mutate the document
     assert doc.as_string() == content

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -954,6 +954,15 @@ class OutOfOrderTableProxy(_CustomDict):  # type: ignore[type-arg]
     def value(self) -> dict[str, Any]:
         return self._internal_container.value
 
+    def __contains__(self, key: object) -> bool:
+        # Native membership test. The inherited ``MutableMapping.__contains__``
+        # resolves the value via ``__getitem__`` (and builds a ``NonExistentKey``
+        # on every absent key) only to discard it. Probe the internal container
+        # directly -- the same predicate ``__getitem__`` already uses -- which is
+        # itself a native ``_map`` lookup that still rebuilds the proxy for an
+        # out-of-order key so its validation runs exactly as before.
+        return key in self._internal_container
+
     def __getitem__(self, key: Key | str) -> Any:
         if key not in self._internal_container:
             raise NonExistentKey(key)


### PR DESCRIPTION
## What

`OutOfOrderTableProxy` was the last mapping type still inheriting the `MutableMapping.__contains__` mixin. That mixin implements `key in proxy` as `try: proxy[key]` — routing through `__getitem__`, which resolves the value (and builds a `NonExistentKey` on every absent key) only to throw it away.

Add a native `__contains__`:

```python
def __contains__(self, key: object) -> bool:
    return key in self._internal_container
```

This is exactly the predicate `__getitem__` already uses as its guard (`if key not in self._internal_container: raise NonExistentKey`), and it is itself a native `Container.__contains__` — which still rebuilds the proxy for an out-of-order key so its validation runs exactly as before.

This completes #483, which added native `__contains__` to `Container`, `Table` and `InlineTable`.

## Iso-functional

Both the old (mixin) and new path bottom out on the same `Container.__contains__`, so the membership result, the raised exception type and document (non-)mutation are identical. Verified by:
- the full test suite incl. the toml-test conformance submodule;
- a new focused test exercising a real `OutOfOrderTableProxy` (present / absent / `Key`-object / non-str→`TypeError` / no document mutation);
- a differential over many out-of-order / nested-proxy / dotted-key / AoT documents and post-mutation states — membership result, exception type and `as_string()` all byte-identical to `master`.

## Benchmark

Membership on an out-of-order proxy (median, interleaved A/B vs `master`):

| | speedup |
|---|---|
| present key | ~2.1× |
| absent key | ~1.3× |

The parse path is untouched (no measurable change there).