### PR TITLE
reject a table redefined after its parent table header

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -112,3 +112,18 @@ def test_parser_rejects_tab_in_bare_key(content: str) -> None:
     parser = Parser(content)
     with pytest.raises(ParseError):
         parser.parse()
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "[a.b]\n[a]\n[a.b]",
+        "[a.b]\nx = 1\n[a]\n[a.b]\ny = 2",
+        "[a.b.c]\n[a]\n[a.b.c]",
+        "[a.b]\n[a.c]\n[a]\n[a.b]",
+    ],
+)
+def test_parser_rejects_table_redefined_after_parent(content: str) -> None:
+    parser = Parser(content)
+    with pytest.raises(ParseError):
+        parser.parse()

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -339,6 +339,14 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                     raise KeyAlreadyPresent(k)
                 if k.is_dotted():
                     raise TOMLKitError("Redefinition of an existing table")
+                if isinstance(existing, Table) and isinstance(v, Table):
+                    if not existing.is_super_table() and not v.is_super_table():
+                        # Both sides are concrete `[table]` definitions of the
+                        # same name; the table is declared twice.
+                        raise KeyAlreadyPresent(k)
+                    # One side is still an implicit/super table, so a duplicate
+                    # (if any) is nested deeper - keep checking the subtree.
+                    self._validate_table_candidate(existing, v)
                 continue
 
             if not k.is_dotted():


### PR DESCRIPTION
## Summary

1. `Container.append` sends a concrete `[table]` header that lands inside an existing implicit/super table through `_validate_table_candidate`, which only flagged a child key on a type change or a dotted-key redefinition.
2. A child table header that was already defined fell through to a plain merge, so a subtable redefined after its parent received its own header (`[a.b]` / `[a]` / `[a.b]`, and the deeper `[a.b.c]` / `[a]` / `[a.b.c]`) was merged silently instead of rejected, while `tomllib` and the toml-test suite treat these as declaring the same table twice.
3. `_validate_table_candidate` now raises when the existing child and the candidate child are both concrete (non-super) tables, and recurses through matching super tables so a duplicate nested deeper is caught as well. Valid out-of-order tables (a new sibling subtable, or extending a table with a deeper header) keep parsing, and the existing tests plus the toml-test 1.0/1.1 suites pass.

## Agent Drafting Metadata

<!-- Fill this section if an AI agent helped draft this PR. -->
- Agent:
- Model:
- Notes:
