### PR TITLE
reject array-of-tables header missing its second closing bracket

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -155,3 +155,18 @@ def test_parser_rejects_table_redefined_after_parent(content: str) -> None:
     parser = Parser(content)
     with pytest.raises(ParseError):
         parser.parse()
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "[[a]b",
+        "[[a]",
+        "[[a]x\ny = 1",
+        "[[a.b]x",
+    ],
+)
+def test_parser_rejects_aot_header_missing_second_bracket(content: str) -> None:
+    parser = Parser(content)
+    with pytest.raises(ParseError):
+        parser.parse()

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -1041,8 +1041,12 @@ class Parser:
 
         self.inc()  # Skip closing bracket
         if is_aot:
-            # TODO: Verify close bracket
-            self.inc()
+            if self.end():
+                raise self.parse_error(UnexpectedEofError)
+            elif self._current != "]":
+                raise self.parse_error(UnexpectedCharError, self._current)
+
+            self.inc()  # Skip second closing bracket
 
         cws, comment, trail = self._parse_comment_trail()
 


### PR DESCRIPTION
## Summary

When a table header is opened with `[[` for an array of tables, `_parse_table` skips the first closing bracket after checking it is `]`, but then consumes a second character as the matching close bracket without verifying it, behind a leftover `# TODO: Verify close bracket`. A header opened with `[[` and closed with a single `]` (or with trailing junk after one `]`, or that hits EOF) is silently accepted: inputs like `[[a]b`, `[[a]`, `[[a.b]x` and `[[a]x` parse as `[[a]]`, and round-tripping rewrites the malformed header to the valid form, so an out-of-spec document is accepted and its text changed under you. tomllib and the toml-test suite reject all of these. The fix mirrors the existing single-bracket check: confirm the second character is `]` (raising `UnexpectedCharError`, or `UnexpectedEofError` at end of input) before consuming it. Added regression tests for the missing-bracket forms.


## Agent Drafting Metadata

<!-- Fill this section if an AI agent helped draft this PR. -->
- Agent:
- Model:
- Notes:
