### PR TITLE
Return a single key from key() for a single-element list (fixes #430)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -365,6 +365,22 @@ def test_add_dotted_key() -> None:
     assert table.as_string() == "foo.bar = 1\n"
 
 
+def test_key_with_single_element_list_is_a_single_key() -> None:
+    # Regression test for
+    # https://github.com/python-poetry/tomlkit/issues/430: a one-element key
+    # list should behave like a plain key, not a single-element dotted key.
+    doc = tomlkit.document()
+    doc.append(tomlkit.key(["foo"]), "value")
+    assert "foo" in doc
+    assert doc["foo"] == "value"
+    assert doc.as_string() == 'foo = "value"\n'
+
+    # Multi-element key lists are still dotted keys.
+    doc = tomlkit.document()
+    doc.add(tomlkit.key(["foo", "bar"]), 1)
+    assert doc.as_string() == "foo.bar = 1\n"
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -262,7 +262,10 @@ def key(k: str | Iterable[str]) -> Key:
     """
     if isinstance(k, str):
         return SingleKey(k)
-    return DottedKey([SingleKey(_k) for _k in k])
+    keys = [SingleKey(_k) for _k in k]
+    if len(keys) == 1:
+        return keys[0]
+    return DottedKey(keys)
 
 
 def value(raw: str) -> _Item:


### PR DESCRIPTION
Fixes #430.

## Problem
`key(["my_key"])` builds a single-element `DottedKey`, which behaves differently from `key("my_key")` (a `SingleKey`). For example:

    import tomlkit
    doc = tomlkit.document()
    doc.append(tomlkit.key(["my_key"]), "value")
    "my_key" in doc        # -> False  (key("my_key") gives True)

## Fix
In `key()`, when the iterable yields exactly one key, return that `SingleKey` instead of wrapping it in a `DottedKey`. Multi-element lists are unchanged (still dotted keys).

## Tests
Added a regression test. The existing suite passes (333 passed, excluding the `toml-test` git submodule which is not initialised in my checkout), and `ruff check` / `ruff format` are clean.