### PR TITLE
raise on malformed array element instead of dropping it

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -73,6 +73,23 @@ def test_malformed_array_still_raises() -> None:
             Parser(content).parse()
 
 
+def test_array_with_malformed_element_raises() -> None:
+    # An element that starts to parse like a value but then hits an
+    # unexpected char (e.g. an inline table missing its "=" or "}") must
+    # surface the error instead of being swallowed and silently dropped,
+    # which left the array truncated to whatever parsed before it.
+    for content in (
+        "a = [{1]",
+        "a = [{a]",
+        "a = [1, {2]",
+        "a = [{a = 1}, {2]",
+        "a = [[1, {x]]",
+        "a = [{a.b]",
+    ):
+        with pytest.raises(UnexpectedCharError):
+            Parser(content).parse()
+
+
 def test_parse_multiline_string_ignore_the_first_newline() -> None:
     content = 'a = """\nfoo\n"""'
     parser = Parser(content)

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -665,12 +665,9 @@ class Parser:
             # exception eagerly computes a line/column, which scans the whole
             # source. On a large file with many arrays this is a big, pure waste.
             if not prev_value and self._current != "]":
-                try:
-                    elems.append(self._parse_value())
-                    prev_value = True
-                    continue
-                except UnexpectedCharError:
-                    pass
+                elems.append(self._parse_value())
+                prev_value = True
+                continue
 
             # consume comma
             if prev_value and self._current == ",":


### PR DESCRIPTION
## Summary

Repro: parse `a = [{1]` or `a = [1, {2]`, an inline table that never reaches its `=`.
Cause: `_parse_array` caught the `UnexpectedCharError` from the element's `_parse_value` and dropped it, so the cursor was left sitting on `]` and the array came back truncated (`[]`, `[1]`) rather than failing on the bad element.
Fix: let the element parse error propagate. The existing `self._current != "]"` guard already handles the empty / trailing-comma case that `except` was covering, so nothing valid changes.

Adds a regression test in `tests/test_parser.py`; full suite including the toml-test 1.1 cases stays green.


## Agent Drafting Metadata

<!-- Fill this section if an AI agent helped draft this PR. -->
- Agent:
- Model:
- Notes: