### PR TITLE
Reject tables inserted into inline tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix `comment()` producing invalid TOML for a multiline string by prefixing every line with `#`, not just the first. ([#449](https://github.com/python-poetry/tomlkit/issues/449))
 - Fix the separator comma being swallowed by a trailing comment when appending a key to a multiline inline table, leaving the new key without a separator so the result no longer round-trips. ([#512](https://github.com/python-poetry/tomlkit/issues/512))
 - Fix a `KeyAlreadyPresent` error when parsing or accessing an out-of-order table whose array-of-tables elements are split across the table's parts. ([#505](https://github.com/python-poetry/tomlkit/issues/505))
+- Reject tables inserted into inline tables instead of serializing invalid TOML. ([#531](https://github.com/python-poetry/tomlkit/issues/531))
 
 ## [0.15.0] - 2026-05-10
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -887,6 +887,17 @@ def test_trim_comments_when_building_inline_table() -> None:
     assert table.as_string() == '{foo = "bar", baz = "foobaz"}'
 
 
+def test_append_table_to_inline_table_raises() -> None:
+    table = api.table()
+    table.append("a", 1)
+    inline_table = api.inline_table()
+
+    with pytest.raises(ValueError, match="cannot contain a table"):
+        inline_table.append("table", table)
+    with pytest.raises(ValueError, match="cannot contain a table"):
+        inline_table["table"] = table
+
+
 def test_deleting_inline_table_element_does_not_leave_trailing_separator() -> None:
     table = api.inline_table()
     table["foo"] = "bar"

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -2035,6 +2035,8 @@ class InlineTable(AbstractTable):
         if not isinstance(_item, Item):
             _item = item(_item, _parent=self)
 
+        self._validate_child(_item)
+
         if not isinstance(_item, (Whitespace, Comment)):
             if not _item.trivia.indent and len(self._value) > 0 and not self._new:
                 _item.trivia.indent = " "
@@ -2050,6 +2052,10 @@ class InlineTable(AbstractTable):
             dict.__setitem__(self, key, _item)
 
         return self
+
+    def _validate_child(self, _item: Item) -> None:
+        if isinstance(_item, Table):
+            raise ValueError("Inline tables cannot contain a table")
 
     def as_string(self) -> str:
         buf = "{"
@@ -2174,6 +2180,9 @@ class InlineTable(AbstractTable):
     def __setitem__(self, key: Key | str, value: Any) -> None:  # type: ignore[override]
         if hasattr(value, "trivia") and value.trivia.comment:
             value.trivia.comment = ""
+        if not isinstance(value, Item):
+            value = item(value, _parent=self)
+        self._validate_child(value)
         super().__setitem__(key, value)
 
     def __copy__(self) -> InlineTable:


### PR DESCRIPTION
## Summary
- Reject `Table` values appended or assigned to an `InlineTable` instead of serializing invalid TOML
- Add a regression test for the public `append()` and item assignment paths
- Update the unreleased changelog

Closes #531

## Tests
- `uv run --no-project --with pytest --with pyyaml python -m pytest tests/test_items.py::test_append_table_to_inline_table_raises -q`
- `uv run --no-project --with pytest --with pyyaml python -m pytest tests/test_items.py tests/test_api.py -q`
- `uv run --no-project --with pytest --with pyyaml python -m pytest -q`
- `uv run --no-project --with ruff ruff check tomlkit tests --exclude tests/toml-test`
- `uv run --no-project --with ruff ruff format --check tomlkit tests --exclude tests/toml-test`
- `git diff --check`

Notes: full `ruff check .` / `ruff format --check .` include the initialized `tests/toml-test` submodule and fail on its upstream `gen.py`. `mypy tomlkit tests --exclude tests/toml-test` currently reports existing strict typing errors on master (for example `source.py` generic annotations and numeric dunder return types in `items.py`).

AI assistance was used under my direction.