### PR TITLE
fix: keep newline after dotted inline table

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1418,6 +1418,19 @@ name = "Nail"
     }
 
 
+def test_add_key_after_dotted_inline_table_without_ending_newline() -> None:
+    content = "[x]\na.b = {}"
+    doc = parse(content)
+    doc["x"]["c"] = 3
+
+    assert doc.as_string() == "[x]\na.b = {}\nc = 3\n"
+
+    doc = parse(f"{content}\n")
+    doc["x"]["c"] = 3
+
+    assert doc.as_string() == "[x]\na.b = {}\nc = 3\n"
+
+
 def test_appending_to_super_table() -> None:
     content = """\
 [a.b]

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -352,6 +352,15 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                 return self._insert_at(last_index, key, item)
             else:
                 previous_item = self._body[-1][1]
+                if isinstance(previous_item, Table) and previous_item.is_super_table():
+                    previous_child = previous_item.value._previous_item()
+                    if (
+                        previous_child is not None
+                        and not isinstance(previous_child, Whitespace)
+                        and "\n" in previous_item.trivia.trail
+                        and "\n" not in previous_child.trivia.trail
+                    ):
+                        previous_child.trivia.trail += previous_item.trivia.trail
                 if not (
                     isinstance(previous_item, Whitespace)
                     or ends_with_whitespace(previous_item)


### PR DESCRIPTION
## Summary
- preserve the trailing newline from a parsed dotted-key super table when appending a following sibling key
- add regression coverage for adding a key after `[x]\na.b = {}` with and without a final newline

Closes #440.

## Tests
- `uv run --no-project --with pytest --with pyyaml python -m pytest tests/test_toml_document.py::test_add_key_after_dotted_inline_table_without_ending_newline -q`
- `uv run --no-project --with pytest --with pyyaml python -m pytest tests/test_toml_document.py -q`
- `uv run --no-project --with pytest --with pyyaml python -m pytest -q` (1024 passed)
- `uv run --no-project --with ruff ruff check tomlkit/container.py tests/test_toml_document.py`
- `uv run --no-project --with ruff ruff format --check tomlkit/container.py tests/test_toml_document.py`
- `git diff --check`

AI assistance was used under my direction.