### PR TITLE
Preserve whitespace when replacing super tables

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -965,6 +965,24 @@ b  =  "how"
     )
 
 
+def test_replace_super_table_preserves_whitespace() -> None:
+    content = """\
+[env.pro1.rst]
+name = "x7"
+
+[env2]
+name = 2
+
+[env3]
+name = 3
+"""
+    doc = parse(content)
+
+    doc["env"] = doc["env"]
+
+    assert doc.as_string() == content
+
+
 def test_replace_with_table_of_nested() -> None:
     example = """\
     [a]

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -1152,9 +1152,12 @@ def ends_with_whitespace(it: Any) -> bool:
     """Returns ``True`` if the given item ``it`` is a ``Table`` or ``AoT`` object
     ending with a ``Whitespace``.
     """
-    return (
-        isinstance(it, Table) and isinstance(it.value._previous_item(), Whitespace)
-    ) or (isinstance(it, AoT) and len(it) > 0 and isinstance(it[-1], Whitespace))
+    if isinstance(it, Whitespace):
+        return True
+    if isinstance(it, Table):
+        previous = it.value._previous_item()
+        return previous is not None and ends_with_whitespace(previous)
+    return isinstance(it, AoT) and len(it) > 0 and ends_with_whitespace(it[-1])
 
 
 def _equal_with_nan(left: Any, right: Any) -> bool:


### PR DESCRIPTION
Fixes https://github.com/python-poetry/tomlkit/issues/352.

## Summary
- treat nested table whitespace as table-ending whitespace when deciding whether to add cosmetic blank lines
- add a regression test for reassigning a parsed super table without changing output

## Verification
- uv run --no-project --with pytest --with pyyaml python -m pytest tests/test_toml_document.py::test_replace_super_table_preserves_whitespace -q
- uv run --no-project --with pytest --with pyyaml python -m pytest tests/test_toml_document.py -q
- uv run --no-project --with pytest --with pyyaml python -m pytest -q
- uv run --no-project --with ruff ruff check tomlkit/container.py tests/test_toml_document.py
- uv run --no-project --with ruff ruff format --check tomlkit/container.py tests/test_toml_document.py
- python -m compileall tomlkit/container.py tests/test_toml_document.py
- git diff --check