### PR TITLE
Represent out-of-order table proxies with merged values

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -846,6 +846,17 @@ inline = {"foo" = "bar", "bar" = "baz"}
     assert repr(doc["namespace"]) == "{'key1': 'value1', 'key2': 'value2'}"
 
 
+def test_repr_out_of_order_table_proxy() -> None:
+    doc = parse("""\
+a.b.c = "d"
+a.b.e = "f"
+""")
+    expected = "{'b': {'c': 'd', 'e': 'f'}}"
+
+    assert repr(doc["a"]) == expected
+    assert str(doc["a"]) == expected
+
+
 def test_deepcopy() -> None:
     content = """
 [tool]

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -1057,6 +1057,12 @@ class OutOfOrderTableProxy(_CustomDict):  # type: ignore[type-arg]
     def value(self) -> dict[str, Any]:
         return self._internal_container.value
 
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __repr__(self) -> str:
+        return repr(self.value)
+
     def __contains__(self, key: object) -> bool:
         # Native membership test. The inherited ``MutableMapping.__contains__``
         # resolves the value via ``__getitem__`` (and builds a ``NonExistentKey``


### PR DESCRIPTION
Fixes https://github.com/python-poetry/tomlkit/issues/439.

## Summary
- make OutOfOrderTableProxy string/repr output use the merged internal container value
- add a regression test for two dotted-key fragments under the same out-of-order proxy

## Verification
- uv run --no-project --with pytest --with pyyaml python -m pytest tests/test_toml_document.py::test_repr_out_of_order_table_proxy tests/test_toml_document.py::test_repr tests/test_toml_document.py::test_out_of_order_tables_are_still_dicts -q
- uv run --no-project --with pytest --with pyyaml python -m pytest -q
- uv run --no-project --with ruff ruff check tomlkit/container.py tests/test_toml_document.py
- uv run --no-project --with ruff ruff format --check tomlkit/container.py tests/test_toml_document.py
- python -m compileall tomlkit/container.py tests/test_toml_document.py
- git diff --check