### PR TITLE
Preserve table display names on self assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix a `KeyAlreadyPresent` error when parsing or accessing an out-of-order table whose array-of-tables elements are split across the table's parts. ([#505](https://github.com/python-poetry/tomlkit/issues/505))
 - Out-of-order value-vs-table and dotted-key-vs-table redefinitions are now rejected at parse time instead of being silently accepted or raising only on access. The parser also detects when a non-dotted key is a prefix of an existing dotted key, matching the stdlib `tomllib` behaviour. ([#523](https://github.com/python-poetry/tomlkit/issues/523))
 - Reject tables inserted into inline tables instead of serializing invalid TOML. ([#531](https://github.com/python-poetry/tomlkit/issues/531))
+- Fix a table's display name (its exact header spelling, including whitespace and quoting) being normalised when the table is assigned onto itself, e.g. `doc[k] = doc[k]` rewriting `[keys .'a'.'c']` to `[keys.a.'c']`. ([#291](https://github.com/python-poetry/tomlkit/issues/291))
 
 ## [0.15.0] - 2026-05-10
 

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1024,6 +1024,20 @@ name = 3
     assert doc.as_string() == content
 
 
+def test_replace_table_with_itself_preserves_display_name() -> None:
+    content = """\
+[keys.a]
+[keys .'a'.'c']
+  'd'	= 'e'
+"""
+    doc = parse(content)
+
+    for mode in doc["keys"]:
+        doc["keys"][mode] = doc["keys"][mode]
+
+    assert doc.as_string() == content
+
+
 def test_replace_with_table_of_nested() -> None:
     example = """\
     [a]

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -928,7 +928,7 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                 value.trivia.trail = v.trivia.trail
             self._body[idx] = (new_key, value)
 
-        if hasattr(value, "invalidate_display_name"):
+        if value is not v and hasattr(value, "invalidate_display_name"):
             value.invalidate_display_name()
 
         if isinstance(value, Table):


### PR DESCRIPTION
Fixes https://github.com/python-poetry/tomlkit/issues/291.

## Summary
- avoid invalidating parsed table display names when a table is assigned back to its existing slot
- add a regression test for preserving whitespace and quoting in dotted table headers after self-assignment

## Verification
- uv run --no-project --with pytest --with pyyaml python -m pytest tests/test_toml_document.py::test_replace_table_with_itself_preserves_display_name tests/test_toml_document.py::test_replace_with_table_of_nested tests/test_toml_document.py::test_nested_table_update_display_name -q
- uv run --no-project --with pytest --with pyyaml python -m pytest -q
- uv run --no-project --with ruff ruff check tomlkit/container.py tests/test_toml_document.py
- uv run --no-project --with ruff ruff format --check tomlkit/container.py tests/test_toml_document.py
- python -m compileall tomlkit/container.py tests/test_toml_document.py
- git diff --check