### PR TITLE
reject overlong decimal integer instead of coercing to inf

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from tomlkit.exceptions import EmptyTableNameError
@@ -201,6 +203,10 @@ def test_parser_rejects_aot_header_missing_second_bracket(content: str) -> None:
         parser.parse()
 
 
+@pytest.mark.skipif(
+    not hasattr(sys, "get_int_max_str_digits"),
+    reason="requires the int-from-string digit limit (3.9.14+/3.10.7+/3.11+)",
+)
 def test_parser_rejects_overlong_decimal_integer() -> None:
     # A decimal integer with more digits than Python's int-from-string limit
     # raises ValueError in int(); it must be reported as an invalid number, not

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,9 +2,11 @@ import pytest
 
 from tomlkit.exceptions import EmptyTableNameError
 from tomlkit.exceptions import InternalParserError
+from tomlkit.exceptions import InvalidNumberError
 from tomlkit.exceptions import InvalidUnicodeValueError
 from tomlkit.exceptions import ParseError
 from tomlkit.exceptions import UnexpectedCharError
+from tomlkit.items import Integer
 from tomlkit.items import StringType
 from tomlkit.parser import Parser
 
@@ -197,3 +199,16 @@ def test_parser_rejects_aot_header_missing_second_bracket(content: str) -> None:
     parser = Parser(content)
     with pytest.raises(ParseError):
         parser.parse()
+
+
+def test_parser_rejects_overlong_decimal_integer() -> None:
+    # A decimal integer with more digits than Python's int-from-string limit
+    # raises ValueError in int(); it must be reported as an invalid number, not
+    # silently fall through to float() and become inf.
+    parser = Parser("a = " + "9" * 4301)
+    with pytest.raises(InvalidNumberError):
+        parser.parse()
+
+    # the value just under the limit is still a normal integer
+    value = Parser("a = " + "9" * 4300).parse()["a"]
+    assert isinstance(value, Integer)

--- a/tomlkit/parser.py
+++ b/tomlkit/parser.py
@@ -786,10 +786,19 @@ class Parser:
         try:
             return Integer(int(sign + clean, base), trivia, sign + raw)
         except ValueError:
+            pass
+
+        # Only fall back to float for an actual float literal (a fractional
+        # dot, a base-10 exponent, or inf/nan). A decimal integer whose digit
+        # count exceeds Python's int-from-string conversion limit also raises
+        # ValueError above; it must be rejected, not silently coerced to inf.
+        if base == 10 and ("." in clean or "e" in clean or clean in ("inf", "nan")):
             try:
                 return Float(float(sign + clean), trivia, sign + raw)
             except ValueError:
                 return None
+
+        return None
 
     def _parse_literal_string(self) -> String:
         with self._state:


### PR DESCRIPTION
## Summary

1. `_parse_number` runs `int(sign + clean, base)` inside a `try/except ValueError` that, on failure, falls back to `float(sign + clean)`.
2. A decimal integer literal with more digits than Python's int-from-string limit (4300 by default) makes `int()` raise `ValueError`, so the literal is parsed as a float instead. A long run of digits ends up as `inf`, so `a = 9999...` (4301+ digits) silently returns a float `inf` rather than being rejected as an out-of-range integer.
3. Restrict the float fallback to literals that are actually float-shaped (a fractional dot, a base-10 exponent, or inf/nan). An integer that `int()` cannot parse now returns `None`, so the parser raises `InvalidNumberError`. Hex/oct/bin literals (no digit limit) and all valid float literals are unaffected.

Repro: `tomlkit.parse("a = " + "9" * 4301)["a"]` returns float `inf` before the change; it raises `InvalidNumberError` after. The 4300-digit value still parses as an `Integer`.


## Agent Drafting Metadata

<!-- Fill this section if an AI agent helped draft this PR. -->
- Agent:
- Model:
- Notes:
