### PR TITLE
Fix item() reordering dict keys when sort_keys is False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fix `item()` reordering a dict's keys — placing dict-valued keys after scalar keys — even with the default `sort_keys=False`, due to a misplaced parenthesis in the list-of-dicts sort key. ([#546](https://github.com/python-poetry/tomlkit/issues/546))
 - Fix invalid serialization with a duplicated comma when removing a non-edge element from a parsed inline table. ([#486](https://github.com/python-poetry/tomlkit/pull/486))
 - Fix invalid serialization with a duplicated comma when appending or inserting into a comma-first formatted array. ([#499](https://github.com/python-poetry/tomlkit/pull/499))
 - Fix `ParseError` when a sub-table extends the last element of an array of tables after an unrelated table. ([#261](https://github.com/python-poetry/tomlkit/issues/261))

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -603,6 +603,17 @@ bar = "baz"
     )
 
 
+def test_item_list_of_dicts_preserves_key_order() -> None:
+    # With the default sort_keys=False, item() must preserve the insertion
+    # order of a dict's keys. A misplaced paren in the list-of-dicts branch
+    # only guarded the secondary sort term, leaving dict-valued keys sorted
+    # after scalar keys even when sort_keys=False (visible in inline tables,
+    # which are not relocated on render). See issue #546.
+    a = item([[{"a": {"x": 1}, "b": 2}]])
+
+    assert a.as_string() == "[[{a = {x = 1}, b = 2}]]"
+
+
 def test_add_float_to_int() -> None:
     content = "[table]\nmy_int = 2043"
     doc = parse(content)

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -167,7 +167,7 @@ def item(value: Any, _parent: Item | None = None, _sort_keys: bool = False) -> I
 
                 for k, _v in sorted(
                     v.items(),
-                    key=lambda i: (isinstance(i[1], dict), i[0] if _sort_keys else 1),
+                    key=lambda i: (isinstance(i[1], dict), i[0]) if _sort_keys else 1,
                 ):
                     i = item(_v, _parent=table, _sort_keys=_sort_keys)
                     if isinstance(table, InlineTable):


### PR DESCRIPTION
## Problem

Resolves #546.

In the list-of-dicts branch of `item()`, the sort-key lambda has a misplaced closing parenthesis:

```python
key=lambda i: (isinstance(i[1], dict), i[0] if _sort_keys else 1)
```

Only `i[0]` is guarded by `if _sort_keys`, so the `isinstance(i[1], dict)` term stays active even with the default `sort_keys=False`, forcing dict-valued keys to sort **after** scalar keys — silently reordering the user's keys. The sibling top-level dict branch already has the correct form (the *whole tuple* guarded):

```python
key=lambda i: (isinstance(i[1], dict), i[0]) if _sort_keys else 1
```

The reorder is masked for regular tables (sub-tables are relocated to the end on render anyway) but is directly visible for inline tables, which are not relocated:

```python
>>> from tomlkit.items import item
>>> item([[{"a": {"x": 1}, "b": 2}]]).as_string()
'[[{b = 2, a = {x = 1}}]]'      # before: b emitted before a
'[[{a = {x = 1}, b = 2}]]'      # after:  insertion order preserved
```

## Fix

Move the parenthesis so the whole tuple is guarded by `if _sort_keys`, matching the sibling branch a few lines above.

## Tests

Added `test_item_list_of_dicts_preserves_key_order`. Full suite passes (`pytest tests/` → 1036 passed). CHANGELOG updated.