### PR TITLE
fix: preserve leading newline of multiline string built with string()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fix `string()` dropping a leading newline of a multiline string on round-trip: a value beginning with a newline is now rendered with an extra leading newline (the one the parser trims after the opening delimiter) so it survives re-parsing.
 - Fix invalid serialization with a duplicated comma when removing a non-edge element from a parsed inline table. ([#486](https://github.com/python-poetry/tomlkit/pull/486))
 - Fix invalid serialization with a duplicated comma when appending or inserting into a comma-first formatted array. ([#499](https://github.com/python-poetry/tomlkit/pull/499))
 - Fix `ParseError` when a sub-table extends the last element of an array of tables after an unrelated table. ([#261](https://github.com/python-poetry/tomlkit/issues/261))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -506,7 +506,7 @@ def test_create_super_table_with_aot() -> None:
         ({}, "My String\x12", '"My String\\u0012"'),
         ({}, "My String\x7f", '"My String\\u007f"'),
         ({"escape": False}, "My String\u0001", '"My String\u0001"'),
-        ({"multiline": True}, "\nMy\nString\n", '"""\nMy\nString\n"""'),
+        ({"multiline": True}, "\nMy\nString\n", '"""\n\nMy\nString\n"""'),
         ({"multiline": True}, 'My"String', '"""My"String"""'),
         ({"multiline": True}, 'My""String', '"""My""String"""'),
         ({"multiline": True}, 'My"""String', '"""My""\\"String"""'),
@@ -535,6 +535,30 @@ def test_create_super_table_with_aot() -> None:
 def test_create_string(kwargs: dict[str, Any], example: str, expected: str) -> None:
     value = tomlkit.string(example, **kwargs)
     assert value.as_string() == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs, example",
+    [
+        ({"multiline": True}, "\n"),
+        ({"multiline": True}, "\nMy\nString\n"),
+        ({"multiline": True}, "\r\nMy\nString"),
+        ({"multiline": True, "literal": True}, "\nMy\nString"),
+        ({"multiline": True, "literal": True}, "\r\nMy\nString"),
+    ],
+)
+def test_create_multiline_string_with_leading_newline_round_trips(
+    kwargs: dict[str, Any], example: str
+) -> None:
+    """A multiline string whose value starts with a newline must survive a
+    round-trip. The parser trims a newline immediately following the opening
+    delimiter, so the rendered form has to account for it (otherwise the
+    leading newline is silently dropped when the output is parsed again).
+    """
+    value = tomlkit.string(example, **kwargs)
+    assert str(value) == example
+    reparsed = parse(f"k = {value.as_string()}\n")["k"]
+    assert str(reparsed) == example
 
 
 @pytest.mark.parametrize(

--- a/tomlkit/items.py
+++ b/tomlkit/items.py
@@ -2251,6 +2251,13 @@ class String(str, Item):  # type: ignore[misc]
         escaped = type_.escaped_sequences
         string_value = escape_string(value, escaped) if escape and escaped else value
 
+        if type_.is_multiline() and string_value[:1] in ("\n", "\r"):
+            # A newline immediately following the opening delimiter of a
+            # multiline string is trimmed by the parser, so a value that
+            # starts with a newline would otherwise lose it on round-trip.
+            # Emit an extra leading newline (the trimmed one) to preserve it.
+            string_value = "\n" + string_value
+
         return cls(type_, decode(value), string_value, Trivia())
 
 


### PR DESCRIPTION
## Problem

`tomlkit.string(value, multiline=True)` produces output that silently loses a **leading newline** on round-trip.

```python
>>> import tomlkit
>>> s = tomlkit.string("\nfoo", multiline=True)
>>> str(s)                 # the String value is correct
'\nfoo'
>>> s.as_string()          # ...but its serialized form is not
'"""\nfoo"""'
>>> str(tomlkit.parse(f'k = {s.as_string()}\n')["k"])
'foo'                      # <- leading newline dropped!
```

Per the [TOML spec](https://toml.io/en/v1.0.0#string): *"A newline immediately following the opening delimiter will be trimmed."* So `"""\nfoo"""` decodes to `foo`, not `\nfoo`. The `String` object reports the right value, but its rendered form is wrong, so the data loss only appears after the output is parsed again.

This is a genuine serialization bug, **not** a TOML 1.0 vs 1.1 difference — both `tomllib` (1.0.0) and tomlkit's own parser (1.1.0) decode the old output to the wrong value:

| `string(value, multiline=True).as_string()` | reparses to (before) | reparses to (after) |
|---|---|---|
| `"\n"` → `"""\n"""` | `""` ❌ | `"\n"` ✅ |
| `"\nabc"` → `"""\nabc"""` | `"abc"` ❌ | `"\nabc"` ✅ |
| `"\r\nx"` → `"""\r\nx"""` | `"x"` ❌ | `"\r\nx"` ✅ |
| `"abc\n"` → `"""abc\n"""` | `"abc\n"` ✅ (unchanged) | `"abc\n"` ✅ |

Affects both basic (`"""`) and literal (`'''`) multiline strings, and values starting with `\r\n`.

## Root cause

In `String.from_raw` (`tomlkit/items.py`), the rendered body is placed directly between the delimiters. For a multiline type, `\n`/`\r` are intentionally kept literal (not escaped) for readability — but nothing accounts for the parser's rule that trims the first newline after the opening delimiter, so a body beginning with a newline is one newline short after re-parsing.

## Fix

When the string is multiline and its rendered body begins with a newline, emit an **extra** leading newline — the one the parser trims — so the intended value survives the round-trip. This is exactly the representation the spec prescribes for such values. Single-line strings and multiline strings that don't start with a newline are unchanged (surgical, +7 lines).

## Tests

- An existing `test_create_string` case asserted the old lossy output (`"""\nMy\nString\n"""`). It only checked `as_string()`, never a round-trip, so it had **locked in the bug**. Updated it to the correct, round-trippable rendering.
- Added `test_create_multiline_string_with_leading_newline_round_trips`, covering basic/literal multiline and `\r\n`-leading values, asserting `parse(render(v)) == v`.

Proof the regression test guards the fix (source change stashed, tests kept):

```
# without the source fix:
6 failed, 32 passed        # 5 new round-trip cases + the corrected case
# with the fix restored:
38 passed
```

Full suite: **1040 passed** (was 1035), `ruff check` clean, `ruff format --check` clean on changed files.
