### PR TITLE
fix: don't reject an out-of-order super-table extended by a dotted key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased]
+
+### Fixed
+
+- Fix valid TOML being rejected when an out-of-order table reopens an implicit super-table with a dotted key: `[a.b.c]` then `[a]` with `b.z = 1` extends the implicit `a.b` super-table rather than redefining it (stdlib `tomllib` accepts it), so it now parses and round-trips instead of raising `Redefinition of an existing table`. The concrete-table case (`[a.b]` then `[a]` `b.z = 1`) stays rejected. ([#565](https://github.com/python-poetry/tomlkit/pull/565))
+
 ## [0.15.1] - 2026-07-17
 
 ### Changed

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -643,6 +643,17 @@ def test_valid_out_of_order_independent_tables() -> None:
     assert doc.as_string() == "[a]\nx=1\n[zz]\n[a.b]\nc=1\n"
 
 
+def test_valid_out_of_order_super_table_extended_by_dotted_key() -> None:
+    # A deep header [a.b.c] makes a.b an implicit super-table; reopening [a] and
+    # extending a.b via a dotted key (b.z) only adds a key to that super-table,
+    # it is not a table redefinition.  stdlib tomllib accepts this, so it must
+    # parse and round-trip byte-for-byte rather than raise. (The concrete-table
+    # form `[a.b]` then `[a]` `b.z=1` stays rejected, covered above.)
+    doc = parse("[a.b.c]\n[a]\nb.z = 1\n")
+    assert doc.unwrap() == {"a": {"b": {"c": {}, "z": 1}}}
+    assert doc.as_string() == "[a.b.c]\n[a]\nb.z = 1\n"
+
+
 def test_set_value_on_out_of_order_table_with_empty_concrete_part() -> None:
     # A super table defined after its sub-table (the "defining a super-table
     # afterward is ok" spec example) leaves an empty concrete `[x]` part.

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -426,7 +426,9 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                 existing = current.value.item(k)
                 if isinstance(existing, (Table, AoT)) != isinstance(v, (Table, AoT)):
                     raise KeyAlreadyPresent(k)
-                if k.is_dotted():
+                if k.is_dotted() and not (
+                    isinstance(existing, Table) and existing.is_super_table()
+                ):
                     raise TOMLKitError("Redefinition of an existing table")
                 if isinstance(existing, Table) and isinstance(v, Table):
                     if not existing.is_super_table() and not v.is_super_table():


### PR DESCRIPTION
## Summary

tomlkit rejects valid TOML on the `parse()` path when an out-of-order table reopens an implicit **super-table** with a dotted key.

`[a.b.c]` makes `a.b` an implicit super-table. Reopening `[a]` and extending `a.b` with a dotted key (`b.z = 1`) only adds a key to that super-table — it is not a redefinition — but `Container._validate_table_candidate` raises `Redefinition of an existing table`:

```python
import tomlkit, tomllib
doc = "[a.b.c]\n[a]\nb.z = 1\n"
tomllib.loads(doc)   # -> {'a': {'b': {'c': {}, 'z': 1}}}   (accepted)
tomlkit.parse(doc)   # -> ParseError: Redefinition of an existing table at line 3 col 0
```

stdlib `tomllib` — the validity oracle the existing tests already cite (`test_reject_out_of_order_dotted_*` reference it) — accepts it.

**Cause:** the `if k.is_dotted(): raise` guard in `_validate_table_candidate` fires *before* the super-table recursion right below it, so a dotted key whose existing side is a super-table never gets to the recursion that would check the subtree for a real conflict. The dotted rejection is only correct when the existing side is a **concrete** table.

**Fix:** only take the dotted-key rejection when the existing entry is not a super-table; otherwise fall through to the existing recursion (which raises only on an actual redefinition). Two lines.

The concrete-table case (`[a.b]` then `[a]` `b.z = 1`) stays rejected, matching `tomllib` and the redefinition rejections added in #516 / #530 — all 27 out-of-order / redefinition tests still pass, and the full suite passes (372, including the new regression test). The target case now parses, round-trips byte-for-byte, and `unwrap()` matches `tomllib`.

Regression test added next to the sibling out-of-order tests in `tests/test_toml_document.py`; it is red before the fix (ParseError) and green after.

> Note: I also noticed a *separate* pre-existing defect where `parse()` succeeds but `.unwrap()` raises `KeyAlreadyPresent` on some valid AoT-based out-of-order docs (e.g. `[[y.a]]\n[b.d.x]\n[[y.a.c]]`). That's a different code path (AoT merge) and is **not** touched here — flagging only in case it's of interest.

## Agent Drafting Metadata

- Agent: Claude Code
- Model: Claude Opus 4.8
- Notes: An AI-assisted review pass surfaced the over-rejection; the repro against `tomllib`, the fix, the regression test, and the full-suite run were verified before opening. I read the `_validate_table_candidate` logic and confirmed the fix preserves every intended rejection (#516/#530) myself.
