### PR TITLE
Reject empty key part lists in key()

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -313,6 +313,14 @@ def test_key() -> None:
     assert isinstance(k, Key)
 
 
+def test_key_rejects_empty_iterable() -> None:
+    # Empty key parts would serialize as " = 1", which is not valid TOML.
+    with pytest.raises(ValueError, match="at least one key part"):
+        tomlkit.key([])
+    with pytest.raises(ValueError, match="at least one key part"):
+        tomlkit.key(())
+
+
 def test_key_value() -> None:
     k, i = tomlkit.key_value("foo = 12")
 

--- a/tomlkit/api.py
+++ b/tomlkit/api.py
@@ -263,6 +263,8 @@ def key(k: str | Iterable[str]) -> Key:
     if isinstance(k, str):
         return SingleKey(k)
     keys = [SingleKey(_k) for _k in k]
+    if not keys:
+        raise ValueError("key() requires at least one key part")
     if len(keys) == 1:
         return keys[0]
     return DottedKey(keys)


### PR DESCRIPTION
tomlkit.key hits DataLoss when key([]) dumps as ' = 1' invalid TOML. This PR fixes the regression with a focused test covering the case.