### PR TITLE
Speed up repeated scalar insertion with boundary bisection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased]
+
+### Changed
+
+- Speed up repeated scalar insertion by binary-searching the scalar/table boundary and updating only mapped keys in the shifted suffix. ([#540](https://github.com/python-poetry/tomlkit/issues/540))
+
 ## [0.15.1] - 2026-07-17
 
 ### Changed

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -1666,3 +1666,44 @@ a.b = 1
     doc["z"] = 2
 
     assert doc.as_string() == "a.b = 1\nz = 2\n"
+
+
+def test_appending_scalars_without_child_tables_keeps_trailing_spacing() -> None:
+    # https://github.com/python-poetry/tomlkit/issues/540
+    doc = parse("[t]\n\n[next]\n")
+    table = doc["t"]
+
+    for i in range(100):
+        table[f"k{i}"] = i
+
+    assert doc.as_string().startswith("[t]\nk0 = 0\nk1 = 1\n")
+    assert "k99 = 99\n\n[next]\n" in doc.as_string()
+    assert doc.unwrap()["t"]["k99"] == 99
+
+
+@pytest.mark.parametrize(
+    ("child_header", "separator"), [("[t.a]", "\n\n"), ("[[t.a]]", "\n")]
+)
+def test_appending_scalars_before_child_table(
+    child_header: str, separator: str
+) -> None:
+    # A child table keeps scalar values in the parent table's body. Find that
+    # boundary without scanning either the scalar or table region in full.
+    doc = parse(f"[t]\n{child_header}\n")
+    table = doc["t"]
+
+    for i in range(100):
+        table[f"k{i}"] = i
+
+    assert doc.as_string().startswith("[t]\nk0 = 0\nk1 = 1\n")
+    assert f"k99 = 99{separator}{child_header}\n" in doc.as_string()
+    assert parse(doc.as_string()).unwrap() == doc.unwrap()
+
+
+def test_appending_scalar_before_whitespace_and_child_table() -> None:
+    doc = parse("[t]\na = 1\n\n[t.child]\nb = 2\n")
+    table = doc["t"]
+
+    table["c"] = 3
+
+    assert doc.as_string() == "[t]\na = 1\nc = 3\n\n[t.child]\nb = 2\n"

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -151,30 +151,43 @@ class Container(_CustomDict):  # type: ignore[type-arg]
         return
 
     def _get_last_index_before_table(self) -> int:
-        last_index = -1
-        for i, (k, v) in enumerate(self._body):
-            if isinstance(v, Null):
-                continue  # Null elements are inserted after deletion
+        # Scalar values precede tables in the body, so find their boundary
+        # without scanning either region in full.
+        low = 0
+        high = len(self._body)
+        while low < high:
+            mid = (low + high) // 2
+            if self._is_table_region(mid):
+                high = mid
+            else:
+                low = mid + 1
+        return low
 
-            if isinstance(v, Whitespace) and not v.is_fixed():
-                continue
-
-            if isinstance(v, (Table, AoT)) and k is not None and not k.is_dotted():
-                break
-
-            if (
-                isinstance(v, Table)
-                and k is not None
-                and k.is_dotted()
-                and self._renders_table_header(v)
+    def _is_table_region(self, index: int) -> bool:
+        # Nulls and non-fixed whitespace do not define the boundary. Give them
+        # the classification of the next meaningful item so whitespace between
+        # scalars stays with the scalar region, while whitespace immediately
+        # before a table stays with the table region. Trailing ignored items are
+        # always after the last scalar and therefore belong to the table side.
+        while index < len(self._body):
+            key, value = self._body[index]
+            if not (
+                isinstance(value, Null)
+                or (isinstance(value, Whitespace) and not value.is_fixed())
             ):
-                # A dotted-key super table renders inline (`a.b = 1`) only as
-                # long as none of its children render a `[table]` header; once
-                # one does, anything appended after it would land inside that
-                # table's scope.
-                break
-            last_index = i
-        return last_index + 1
+                return (
+                    isinstance(value, (Table, AoT))
+                    and key is not None
+                    and (
+                        not key.is_dotted()
+                        or (
+                            isinstance(value, Table)
+                            and self._renders_table_header(value)
+                        )
+                    )
+                )
+            index += 1
+        return True
 
     def _renders_table_header(self, table: Table) -> bool:
         for k, v in table.value.body:
@@ -393,7 +406,12 @@ class Container(_CustomDict):  # type: ignore[type-arg]
                     or "\n" in after_item.trivia.indent
                 ):
                     after_item.trivia.indent = "\n" + after_item.trivia.indent
-                return self._insert_at(last_index, key, item)
+                return self._insert_at(
+                    last_index,
+                    key,
+                    item,
+                    update_table_indices_only=not is_table,
+                )
             else:
                 previous_item = self._body[-1][1]
                 if isinstance(previous_item, Table) and previous_item.is_super_table():
@@ -560,7 +578,13 @@ class Container(_CustomDict):  # type: ignore[type-arg]
 
         return self
 
-    def _insert_at(self, idx: int, key: Key | str, item: Any) -> Container:
+    def _insert_at(
+        self,
+        idx: int,
+        key: Key | str,
+        item: Any,
+        update_table_indices_only: bool = False,
+    ) -> Container:
         if idx > len(self._body) - 1:
             raise ValueError(f"Unable to insert at position {idx}")
 
@@ -579,8 +603,18 @@ class Container(_CustomDict):  # type: ignore[type-arg]
             ):
                 previous_item.trivia.trail += "\n"
 
-        # Increment indices after the current index
-        for k, v in self._map.items():
+        # Values inserted at the scalar/table boundary only shift table keys;
+        # every scalar key is before ``idx`` already. Avoid visiting all prior
+        # scalar keys on every insertion, which made bulk insertion quadratic.
+        keys = (
+            dict.fromkeys(k for k, _ in self._body[idx:] if k is not None)
+            if update_table_indices_only
+            else self._map
+        )
+        for k in keys:
+            v = self._map.get(k)
+            if v is None:
+                continue
             if isinstance(v, tuple):
                 new_indices = []
                 for v_ in v:


### PR DESCRIPTION
## Summary

Closes #540.

Appending a scalar may need to place the new value before child table headers. Two full-prefix operations made repeated insertion quadratic:

1. `_get_last_index_before_table()` scanned every existing scalar to find the boundary.
2. `_insert_at()` visited every mapped scalar to increment indices, even though only items in the shifted suffix moved.

This change binary-searches the monotonic scalar/table boundary, so it scans neither the scalar prefix nor the table suffix in full. Null entries and non-fixed whitespace inherit the classification of the next meaningful item, preserving the old insertion boundary exactly. Insertion then updates only mapped keys in the suffix that actually shifts.

The remaining cost when the table suffix itself grows comes from Python list insertion and the required index shifts, not from trading a scalar scan for a table scan.

## Correctness checks

- compared the new boundary with the previous forward scan across 744 containers parsed from 287 repository TOML fixtures: 0 mismatches
- an 8,192-item container containing 4,096 scalars and 4,096 tables required 13 body reads to find the boundary
- added regression coverage for blank whitespace immediately before a child table
- existing tests cover regular child tables, arrays of child tables, trailing spacing, index integrity, and round-tripping

## Benchmark

Same machine and CPython 3.12, with GC collected and disabled for each insertion loop:

| Layout | Inserts | master | this branch |
| --- | ---: | ---: | ---: |
| `[t]` | 1,000 | 226 ms | 17 ms |
| `[t]` | 2,000 | 789 ms | 31 ms |
| `[t]` | 4,000 | 3.19 s | 64 ms |
| `[t]` + `[t.child]` | 1,000 | 226 ms | 15 ms |
| `[t]` + `[t.child]` | 2,000 | 861 ms | 32 ms |
| `[t]` + `[t.child]` | 4,000 | 3.45 s | 66 ms |
| `[t]` + 256 child tables | 500 | 75 ms | 51 ms |
| `[t]` + 256 child tables | 1,000 | 270 ms | 101 ms |
| `[t]` + 256 child tables | 2,000 | 937 ms | 201 ms |

## Validation

- complete test suite: 1,055 passed
- focused document tests: 75 passed
- Ruff 0.15.1 check: passed
- Ruff 0.15.1 format check: passed
- focused mypy 1.19.1 run: passed
- diff whitespace check: passed

## Agent Drafting Metadata

- Agent: OpenAI Codex
- Model: GPT-5 family, Codex
- Notes: Codex diagnosed the performance paths, drafted the change and regression tests, ran the full validation suite, compared the boundary against the previous implementation across repository fixtures, and measured the before/after benchmarks. David authorized the contribution and owns the submission.
