### PR TITLE
fix: deleting a key added before a table leaves a blank line behind

### DIFF
--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -361,6 +361,44 @@ def test_inserting_after_deletion() -> None:
     assert expected == doc.as_string()
 
 
+def test_deleting_key_added_before_a_table_restores_the_document() -> None:
+    content = """[a]
+x = 1
+"""
+
+    doc = parse(content)
+    doc["foo"] = 10
+
+    assert (
+        doc.as_string()
+        == """foo = 10
+
+[a]
+x = 1
+"""
+    )
+
+    del doc["foo"]
+
+    assert doc.as_string() == content
+
+
+def test_adding_keys_before_a_table_separates_them_from_it_once() -> None:
+    doc = parse("[a]\nx = 1\n")
+    doc["foo"] = 10
+    doc["bar"] = 11
+
+    assert (
+        doc.as_string()
+        == """foo = 10
+bar = 11
+
+[a]
+x = 1
+"""
+    )
+
+
 def test_toml_document_with_dotted_keys_inside_table(
     example: Callable[[str], str],
 ) -> None:

--- a/tomlkit/container.py
+++ b/tomlkit/container.py
@@ -150,6 +150,16 @@ class Container(_CustomDict):  # type: ignore[type-arg]
         self.append(name, table)
         return
 
+    def _trail_table_separator_on(self, item: Item, before_index: int) -> None:
+        if before_index > 0:
+            previous = self._body[before_index - 1][1]
+            if not isinstance(previous, Whitespace) and previous.trivia.trail.endswith(
+                "\n\n"
+            ):
+                previous.trivia.trail = previous.trivia.trail[:-1]
+
+        item.trivia.trail += "\n"
+
     def _get_last_index_before_table(self) -> int:
         last_index = -1
         for i, (k, v) in enumerate(self._body):
@@ -388,7 +398,13 @@ class Container(_CustomDict):  # type: ignore[type-arg]
 
             if last_index < len(self._body):
                 after_item = self._body[last_index][1]
-                if not (
+                if (
+                    not is_table
+                    and isinstance(after_item, Table)
+                    and "\n" not in after_item.trivia.indent
+                ):
+                    self._trail_table_separator_on(item, before_index=last_index)
+                elif not (
                     isinstance(after_item, Whitespace)
                     or "\n" in after_item.trivia.indent
                 ):


### PR DESCRIPTION
## Summary

Adding a key to a document that begins with a table inserts a blank line to separate the new key from `[a]`. Deleting that key leaves the blank line behind, so the round trip doesn't restore the original document.

```python
doc = tomlkit.parse("[a]\nx = 1\n")
doc["foo"] = 10
del doc["foo"]
doc.as_string()   # 0.15.1 gives '\n[a]\nx = 1\n', expected '[a]\nx = 1\n'
```

The separator was stored as the table's `indent`, so it outlived the key it was inserted for. It now trails the inserted item and is removed along with it. Repeated inserts still yield exactly one blank line, the behaviour asked for in #178, and there's a test covering that as well.

1053 tests pass.

## Agent Drafting Metadata

- Agent: Claude Code
- Model: claude-opus-5
- Notes: Found by round-trip differential testing against 0.15.1.
